### PR TITLE
no need for procmail when using fetchmail

### DIFF
--- a/channel-fetchmail.rst
+++ b/channel-fetchmail.rst
@@ -26,6 +26,7 @@ Create .fetchmailrc
  su - zammad
  cd ~
  touch .fetchmailrc
+ chmod 0600 .fetchmailrc
 
 
 vi .fetchmailrc
@@ -36,7 +37,7 @@ vi .fetchmailrc
  #
  # zammad fetchmail config
  #
- poll your.mail.server protocol POP3 user USERNAME pass PASSWORD mda /usr/bin/procmail is zammad here
+ poll your.mail.server protocol POP3 user USERNAME pass PASSWORD mda "rails r 'Channel::Driver::MailStdin.new(trusted: true)'"
 
 
 


### PR DESCRIPTION
It's no problem to use fetchmail without procmail. Tested on a production instance (EL7, Zammad 1.3.x):

![image](https://cloud.githubusercontent.com/assets/378324/23043979/91bf7afe-f49e-11e6-8242-1e3414d9d917.png)
