### PR TITLE
Typo - no need to 'cd zammad'

### DIFF
--- a/install-source.rst
+++ b/install-source.rst
@@ -22,7 +22,6 @@ Please note that a working ruby 2.3.1 environment is needed.
 
 ::
 
- zammad@shell> cd zammad
  zammad@shell> gem install bundler rake rails
 
 For PostgreSQL (note, the option says "without ... mysql")


### PR DESCRIPTION
"su -" will actually put you in the right directory... doing the "cd zammad" will actually trigger an error because /opt/zammad doesn't exist