### PR TITLE
PostgreSQL restart effects zammad

### DIFF
--- a/install-source.rst
+++ b/install-source.rst
@@ -36,6 +36,8 @@ For PostgreSQL (note, the option says "without ... mysql")
 ::
 
  zammad@shell> bundle install --without test development mysql
+ 
+ Please note: everytime you upgrade or restart PostgreSQL you have to restart all zammad services in order to work properly!
 
 For MySQL (note, the option says "without ... postgres")
 --------------------------------------------------------


### PR DESCRIPTION
Zammad needs to be restarted everytime you restart postgreSQL or update it in order to work properly.