### PR TITLE
adding android-api-client to docs

### DIFF
--- a/api-intro.rst
+++ b/api-intro.rst
@@ -235,3 +235,5 @@ API clients
 * Ruby Client - https://github.com/zammad/zammad-api-client-ruby
 * PHP Client - https://github.com/zammad/zammad-api-client-php
 * .NET Client - https://github.com/Asesjix/Zammad-Client
+* Android API-Client - https://github.com/KirkBushman/zammad-android
+  .. Note:: Please note that this is a API client only, it's no "ready to use" App.


### PR DESCRIPTION
This will add a reference to the android API Client.
As discussed on https://community.zammad.org/t/zammad-android-client/2946/3