### PR TITLE
Fixing code snipped for making states available to UI

### DIFF
--- a/console/working-on-tickets.rst
+++ b/console/working-on-tickets.rst
@@ -130,13 +130,13 @@ Make new states available to UI
 
 Before being able to use the new states within the WebApp, you need to run the following commands to make them available.
 
-.. Note:: Please replace ``{State-Name}`` with the earlier chosen State-Name. Rails will lookup the state ID for you.
+.. Warn:: Please **do not replace** anything below, state_id is a named attribute which is correct and shall not be replaced!
 
 ::
 
     attribute = ObjectManager::Attribute.get(
       object: 'Ticket',
-      name: '{State-Name}',
+      name: 'state_id',
     )
     attribute.data_option[:filter] = Ticket::State.by_category(:viewable).pluck(:id)
     attribute.screens[:create_middle]['ticket.agent'][:filter] = Ticket::State.by_category(:viewable_agent_new).pluck(:id)

--- a/console/working-on-tickets.rst
+++ b/console/working-on-tickets.rst
@@ -129,11 +129,14 @@ Make new states available to UI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before being able to use the new states within the WebApp, you need to run the following commands to make them available.
+
+.. Note:: Please replace ``{State-Name}`` with the earlier chosen State-Name. Rails will lookup the state ID for you.
+
 ::
 
     attribute = ObjectManager::Attribute.get(
       object: 'Ticket',
-      name: 'state_id',
+      name: '{State-Name}',
     )
     attribute.data_option[:filter] = Ticket::State.by_category(:viewable).pluck(:id)
     attribute.screens[:create_middle]['ticket.agent'][:filter] = Ticket::State.by_category(:viewable_agent_new).pluck(:id)

--- a/console/working-on-tickets.rst
+++ b/console/working-on-tickets.rst
@@ -121,8 +121,7 @@ To add the time picker (pending till) to the new pending state, you'll need to e
     attribute.save!
 
 
-Note: In enhanced cases you might want do define the ``state_id`` on your own. In this case just pick the returned ``state_id`` from ``Ticket::State.by_category(:pending).pluck(:id)`` and use them with 
-  ``attribute.data_option[:required_if][:state_id] = {state_id(s)}`` and ``attribute.data_option[:shown_if][:state_id] = {state_id(s)}`` directly. Don't forget to save!
+.. Note:: In enhanced cases you might want do define the ``state_id`` on your own. In this case just pick the returned ``state_id`` from ``Ticket::State.by_category(:pending).pluck(:id)`` and use them with ``attribute.data_option[:required_if][:state_id] = {state_id(s)}`` and ``attribute.data_option[:shown_if][:state_id] = {state_id(s)}`` directly. Don't forget to save!
 
 
 


### PR DESCRIPTION
Affected documentation part:
https://docs.zammad.org/en/latest/console/working-on-tickets.html#make-new-states-available-to-ui

We currently hold the following code snipped:
```
attribute = ObjectManager::Attribute.get(
  object: 'Ticket',
  name: 'state_id',
)
```

The above actually is wrong and suggest to insert the created states ID which is wrong. The snipped needs to be like this:

```
attribute = ObjectManager::Attribute.get(
  object: 'Ticket',
  name: 'state_name',
)
```

This PR fixes this issue and also fixes a typo / visual thing for the earlier corrected "adding a time picker for pending states".

Martin, could you please check the code snippet-Part? :)
Thank you!