### PR TITLE
Fixed user switch to zammad user (behaviour of 'su' changed in Debian)

### DIFF
--- a/install-source.rst
+++ b/install-source.rst
@@ -153,8 +153,7 @@ Get Zammad
 
 ::
 
- su zammad
- cd ~
+ su - zammad
  curl -O https://ftp.zammad.com/zammad-latest.tar.gz
  tar -xzf zammad-latest.tar.gz
  rm zammad-latest.tar.gz


### PR DESCRIPTION
- Debian/Ubuntu has replaced 'su' implementation with util-linux
(see: "https://sources.debian.org/src/util-linux/2.33.1-0.1/debian/util-linux.NEWS/")
- from then on 'su' should be used with '-' to get a clean environment