### PR TITLE
Add ticket article commands for console (SLA communication)

### DIFF
--- a/admin/console.rst
+++ b/admin/console.rst
@@ -54,6 +54,7 @@ Here's a topic list for quick jumping and better overview.
    console/hidden-settings
    console/working-on-users
    console/working-on-tickets
+   console/working-on-ticket-articles
    console/working-on-groups
    console/working-on-chat
    console/other-usefull-commands

--- a/admin/console/hidden-settings.rst
+++ b/admin/console/hidden-settings.rst
@@ -4,7 +4,7 @@ Advanced customization settings
 On this page you can find some settings that you won't find within the Zammad UI.
 Those settings might come in handy as it can change Zamnmads behavior.
 
-.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at our `Community <https://community.zammad.org>`_.
+.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
 Send all outgoing E-Mails to a BCC-Mailbox
 ------------------------------------------

--- a/admin/console/other-usefull-commands.rst
+++ b/admin/console/other-usefull-commands.rst
@@ -1,7 +1,7 @@
 Other useful commands
 **********************
 
-.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at our `Community <https://community.zammad.org>`_.
+.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
 Fetch mails
 -----------

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -11,7 +11,7 @@ By default, Zammad ignores notes with SLA activated. You might also want to ensu
 
 .. note:: The command below will only affect public notes, Zammad will still ignore private notes for SLA calculation!
 
-.. warning:: Changing notes to a communication article disables the possibility to delete those notes.
+.. warning:: Changing this setting will disable the option to delete public notes.
 
 .. code-block:: ruby
 

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -6,8 +6,9 @@ Working with ticket articles
 Count Public “Notes” toward SLAs
 --------------------------------
 
-In some cases you might want to count note articles to your `service level agreements <https://admin-docs.zammad.org/en/latest/manage-slas.html>`_. 
-By default, Zammad ignores notes with SLA activated. You might also want to ensure that public notes will be sent to the customer by a `Trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_, because Zammad does not check for this!
+Normally, `notes <https://user-docs.zammad.org/en/latest/basics/service-ticket/follow-up.html#adding-new-messages-notes>`_ don't count toward `service-level agreements <https://admin-docs.zammad.org/en/latest/manage-slas.html>`_.
+Use the following command to include publicly-visible notes when tracking SLA compliance.
+(Internal notes cannot be made to apply toward SLAs.)
 
 .. note:: By default, customers are not notified when public notes are added to a ticket. Set up a `trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_ if you wish to change this behavior. 
 

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -3,8 +3,8 @@ Working with ticket articles
 
 .. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
-Change notes to communication articles for SLA calculation
-----------------------------------------------------------
+Count Public “Notes” toward SLAs
+--------------------------------
 
 In some cases you might want to count note articles to your `service level agreements <https://admin-docs.zammad.org/en/latest/manage-slas.html>`_. 
 By default, Zammad ignores notes with SLA activated. You might also want to ensure that public notes will be sent to the customer by a `Trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_, because Zammad does not check for this!

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -1,0 +1,19 @@
+Working with ticket articles
+****************************
+
+.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
+
+Change notes to communication articles for SLA calculation
+----------------------------------------------------------
+
+In some cases you might want to count note articles to your `service level agreements <https://admin-docs.zammad.org/en/latest/manage-slas.html>`_. 
+By default, Zammad ignores notes with SLA activated. You might also want to ensure that public notes will be sent to the customer by a `Trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_, because Zammad does not check for this!
+
+.. note:: The command below will only affect public notes, Zammad will still ignore private notes for SLA calculation!
+
+.. warning:: Changing notes to a communication article disables the possibility to delete those notes.
+
+.. code-block:: ruby
+
+  >> Ticket::Article::Type.find_by(name:'note').update!(communication: true)    # Enable SLA to count notes as communication
+  >> Ticket::Article::Type.find_by(name:'note').update!(communication: false)   # Enable SLA to ignore notes as communication

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -15,5 +15,5 @@ By default, Zammad ignores notes with SLA activated. You might also want to ensu
 
 .. code-block:: ruby
 
-  >> Ticket::Article::Type.find_by(name:'note').update!(communication: true)    # Enable SLA to count notes as communication
-  >> Ticket::Article::Type.find_by(name:'note').update!(communication: false)   # Enable SLA to ignore notes as communication
+   >> Ticket::Article::Type.find_by(name:'note').update!(communication: true)    # Enable SLA to count notes as communication
+   >> Ticket::Article::Type.find_by(name:'note').update!(communication: false)   # Enable SLA to ignore notes as communication

--- a/admin/console/working-on-ticket-articles.rst
+++ b/admin/console/working-on-ticket-articles.rst
@@ -9,7 +9,7 @@ Count Public “Notes” toward SLAs
 In some cases you might want to count note articles to your `service level agreements <https://admin-docs.zammad.org/en/latest/manage-slas.html>`_. 
 By default, Zammad ignores notes with SLA activated. You might also want to ensure that public notes will be sent to the customer by a `Trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_, because Zammad does not check for this!
 
-.. note:: The command below will only affect public notes, Zammad will still ignore private notes for SLA calculation!
+.. note:: By default, customers are not notified when public notes are added to a ticket. Set up a `trigger <https://admin-docs.zammad.org/en/latest/manage-trigger.html>`_ if you wish to change this behavior. 
 
 .. warning:: Changing this setting will disable the option to delete public notes.
 

--- a/admin/console/working-on-tickets.rst
+++ b/admin/console/working-on-tickets.rst
@@ -1,7 +1,7 @@
 Working with ticket information
 *******************************
 
-.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at our `Community <https://community.zammad.org>`_.
+.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
 Get the RAW mail that Zammad fetched
 ------------------------------------

--- a/admin/console/working-on-users.rst
+++ b/admin/console/working-on-users.rst
@@ -1,7 +1,7 @@
 Working on user information
 ***************************
 
-.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at our `Community <https://community.zammad.org>`_.
+.. note:: Please note that this is not a full command list, if you're missing commands, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
 Find user
 ---------

--- a/admin/console/zammad-settings.rst
+++ b/admin/console/zammad-settings.rst
@@ -1,7 +1,7 @@
 Getting and Updating Zammad-Settings
 ************************************
 
-.. note:: Please note that this is not a full setting list, if you're missing settings, feel free to ask over at our `Community <https://community.zammad.org>`_.
+.. note:: Please note that this is not a full setting list, if you're missing settings, feel free to ask over at the `Community <https://community.zammad.org>`_.
 
 
 Get ticket_hook setting


### PR DESCRIPTION
This pull requests comes in two flavors:

* It fixes the wording from "our Community" to "the Community". This is our preferred way to reference the Zammad community forum. This is a small wording thingie.
* It introduces console commands on how to change note articles to a communication article in order to be considered by our SLA calculation. It also features a warning of what will change so the scope hopefully is clear.

@Ryan - can you please have a look when you find some spare time?
I tried to adjust to your styling and hope it's fitting. Wording might be off though. :>