### PR TITLE
Adjust documentation for upcoming 3.4 release

### DIFF
--- a/api/intro.rst
+++ b/api/intro.rst
@@ -221,6 +221,7 @@ API clients
 
 * Ruby Client - https://github.com/zammad/zammad-api-client-ruby
 * PHP Client - https://github.com/zammad/zammad-api-client-php
+* Python Client - https://pypi.org/project/zammad-py/
 * .NET Client - https://github.com/Asesjix/Zammad-Client
 * Android API-Client - https://github.com/KirkBushman/zammad-android
   .. note:: Please note that this is a API client only, it's no "ready to use" App.

--- a/install/docker-compose.rst
+++ b/install/docker-compose.rst
@@ -64,6 +64,10 @@ Maintenance
 Updating Zammad
 ---------------
 
+Before updating, please always check the `readme of the docker-compose repository 
+<https://github.com/zammad/zammad-docker-compose#upgrading>`_.
+This ensures that you won't fall into some unexpected traps!
+
 * docker-compose stop
 * git pull
 * docker-compose pull

--- a/install/docker-compose.rst
+++ b/install/docker-compose.rst
@@ -64,9 +64,10 @@ Maintenance
 Updating Zammad
 ---------------
 
-Before updating, please always check the `readme of the docker-compose repository 
-<https://github.com/zammad/zammad-docker-compose#upgrading>`_.
-This ensures that you won't fall into some unexpected traps!
+.. warning:: ⚠️ **Updates may require extra steps or introduce breaking changes.**
+
+   Always check the `upgrade notes
+   <https://github.com/zammad/zammad-docker-compose#upgrading>`_ first.
 
 * docker-compose stop
 * git pull

--- a/install/source.rst
+++ b/install/source.rst
@@ -28,7 +28,7 @@ You can directly download Zammad from https://ftp.zammad.com/ or use the direct 
 2. Install all dependencies
 ---------------------------
 
-Please note that a working ruby 2.5.5 environment is needed.
+Please note that a working ruby 2.6.5 environment is needed.
 
 .. code-block:: sh
 
@@ -168,8 +168,8 @@ Install environnment
    $ curl -L https://get.rvm.io | bash -s stable
    $ source /opt/zammad/.rvm/scripts/rvm
    $ echo "source /opt/zammad/.rvm/scripts/rvm" >> /opt/zammad/.bashrc
-   $ echo "rvm --default use 2.5.5" >> /opt/zammad/.bashrc
-   $ rvm install 2.5.5
+   $ echo "rvm --default use 2.6.5" >> /opt/zammad/.bashrc
+   $ rvm install 2.6.5
    $ gem install bundler
 
 Install Zammad

--- a/install/source.rst
+++ b/install/source.rst
@@ -8,14 +8,14 @@ Setup Elasticsearch
 -------------------
 
 Elasticsearch is a dependency of Zammad and needs to be provided before installing Zammad.
-Please take a look at the following page: :doc:`/install/elasticsearch` .
+Please take a look at the following page: :doc:`/install/elasticsearch`.
 
 
 1. Install Zammad on your system
 --------------------------------
 
 You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
-you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`.
+you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`_.
 
 .. code-block:: sh
 

--- a/install/source.rst
+++ b/install/source.rst
@@ -14,7 +14,8 @@ Please take a look at the following page: :doc:`/install/elasticsearch` .
 1. Install Zammad on your system
 --------------------------------
 
-You can directly download Zammad from https://ftp.zammad.com/ or use the direct URL to get the latest stable release via https://ftp.zammad.com/zammad-latest.tar.gz
+You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
+you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`.
 
 .. code-block:: sh
 

--- a/install/source.rst
+++ b/install/source.rst
@@ -14,8 +14,8 @@ Please take a look at the following page: :doc:`/install/elasticsearch`.
 1. Install Zammad on your system
 --------------------------------
 
-You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
-you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`_.
+Get the latest stable release of Zammad `here <https://github.com/zammad/zammad/archive/stable.zip>`_,
+or find an older version at https://ftp.zammad.com.
 
 .. code-block:: sh
 

--- a/install/update.rst
+++ b/install/update.rst
@@ -6,17 +6,17 @@ Updating Zammad
 Source update
 =============
 
-1. Ensure your System meets the requirenments
----------------------------------------------
+1. Check your dependencies
+--------------------------
 
-Before updating your installation, please ensure that your system  meets Zammads current 
-:doc:`Software requirenments </prerequisites/software>`.
+Before proceeding, double-check that your system environment
+matches :doc:`Zammad’s requirements </prerequisites/software>`.
 
 2. Download Zammad to your system
 ---------------------------------
 
-You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
-you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`_.
+Get the latest stable release of Zammad `here <https://github.com/zammad/zammad/archive/stable.zip>`_,
+or find an older version at https://ftp.zammad.com.
 
 .. code-block:: sh
 

--- a/install/update.rst
+++ b/install/update.rst
@@ -9,7 +9,8 @@ Source update
 1. Download Zammad to your system
 ---------------------------------
 
-You can directly download Zammad from https://ftp.zammad.com/ or use the direct URL to get the latest stable release via https://ftp.zammad.com/zammad-latest.tar.gz
+You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
+you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`.
 
 .. code-block:: sh
 

--- a/install/update.rst
+++ b/install/update.rst
@@ -6,7 +6,13 @@ Updating Zammad
 Source update
 =============
 
-1. Download Zammad to your system
+1. Ensure your System meets the requirenments
+---------------------------------------------
+
+Before updating your installation, please ensure that your system  meets Zammads current 
+:doc:`Software requirenments </prerequisites/software>`.
+
+2. Download Zammad to your system
 ---------------------------------
 
 You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
@@ -20,7 +26,7 @@ you can also get Zammad directly from `Github <https://github.com/zammad/zammad/
    $ sudo chown -R zammad /opt/zammad
    $ sudo su - zammad
 
-2. Install all dependencies
+3. Install all dependencies
 ---------------------------
 
 .. code-block:: sh
@@ -41,12 +47,12 @@ you can also get Zammad directly from `Github <https://github.com/zammad/zammad/
    zammad@host $ bundle install --without test development postgres
 
 
-3. Stop Zammad services
+4. Stop Zammad services
 -----------------------
 
 Stop the application server, websocket server and scheduler.
 
-4. Upgrade your database
+5. Upgrade your database
 ------------------------
 
 .. code-block:: sh
@@ -56,12 +62,12 @@ Stop the application server, websocket server and scheduler.
    zammad@host $ rake db:migrate
    zammad@host $ rake assets:precompile
 
-5. Start Zammad services
+6. Start Zammad services
 ------------------------
 
 Start the application server, websocket server and scheduler.
 
-6. Go and login to Zammad
+7. Go and login to Zammad
 -------------------------
 
 

--- a/install/update.rst
+++ b/install/update.rst
@@ -10,7 +10,7 @@ Source update
 ---------------------------------
 
 You can directly download Zammad from https://ftp.zammad.com/. If you want to ensure you have the latest stable version, 
-you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`.
+you can also get Zammad directly from `Github <https://github.com/zammad/zammad/archive/stable.zip>`_.
 
 .. code-block:: sh
 

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -11,7 +11,13 @@ The following Ruby version is supported:
 
 * Ruby 2.6.5
 
-.. warning:: We changed our Ruby dependency with Zammad 3.4. Zammad 3.1 to 3.3 requires Ruby 2.5.5 - earlier versions require ruby 2.4.4.
+.. csv-table:: Ruby version requirenment for Zammad
+   :header: "Zammad version", "Ruby version required"
+   :widths: 20, 20
+
+   "3.4+", "2.6.5"
+   "3.1 - 3.3", "2.5.5"
+   "2.5 - 3.0", "2.4.4"
 
 2. Package Dependencies
 =======================

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -70,18 +70,26 @@ The following reverse proxies are supported:
 5. Elasticsearch (optional)
 ===========================
 
-.. note:: Package install will insist on installing elasticsearch, you can break dependencies during install if needed.
+For excellent search performance we use Elasticsearch. 
+While package install will insist on installing Elasticsearch, you can break those dependencies if needed.
 
 .. warning:: Please note that if you do not install and use Elasticsearch, the search will be very limited!
    We recommend using Elasticsearch, as it will boost the usuage of Zammad greatly!
 
-For excellent search performance we use Elasticsearch.
-The following Elasticsearch versions are supported:
+
+The Elasticsearch support differs on the Elasticsearch and Zammad version you're using:
+
+.. csv-table:: Compatibility to Elasticsearch
+   :header: "Zammad version", "Supported Elasticsearch version"
+   :widths: 20, 20
+
+   "3.4+", "5.5 up to 7.6.x"
+   "3.3", "2.4 up to 7.6.x"
+   "3.2", "2.4 up to 7.5.x"
+   "3.1", "2.4 up to 7.4.x"
+   "3.0 - 3.0", "2.4 up to 5.6.x"
+
+As Zammad indexes attachments, you'll need a plugin to do so - the names differ in between Elasticsearch versions:
 
 * Elasticsearch 5.5 with ``mapper-attachments`` plugin
-* Elasticsearch 5.6, 6.x & 7.x with ``ingest-attachment`` plugin
-
-.. warning:: Please note that Elasticsearch 6.x and 7.x support came with Zammad 3.1.
-   If you try to use Elasticsearch newer than 5.6.x on Zammad 3.0 and earlier, your search index will **not work**.
-
-.. warning:: Please note that we will be dropping Elasticsearch support prior 5.5.x on future releases.
+* Elasticsearch 5.6 up to 7.x with ``ingest-attachment`` plugin

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -19,11 +19,6 @@ The following Ruby version is supported:
 The below dependencies need to be installed on your system.
 If you're using the package install, the packages below will automatically installed with the Zammad-Package.
 
-.. note:: The below package dependency was added with Zammad 2.9 which improves image previews.
-
-.. warning:: Please note that upgrading from Zammad 2.8 and earlier might fail, because your system does not satisfy the new dependencies.
-   Below installation commands will help you out (you can update normally afterwards)
-
 .. code-block:: sh
 
    # Debian 8 & 9, Ubuntu 16.04 & 18.04

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -87,7 +87,7 @@ The Elasticsearch support differs on the Elasticsearch and Zammad version you're
    "3.3", "2.4 up to 7.6.x"
    "3.2", "2.4 up to 7.5.x"
    "3.1", "2.4 up to 7.4.x"
-   "3.0 - 3.0", "2.4 up to 5.6.x"
+   "2.0 - 3.0", "2.4 up to 5.6.x"
 
 As Zammad indexes attachments, you'll need a plugin to do so - the names differ in between Elasticsearch versions:
 

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -11,8 +11,8 @@ The following Ruby version is supported:
 
 * Ruby 2.6.5
 
-.. csv-table:: Ruby version requirenment for Zammad
-   :header: "Zammad version", "Ruby version required"
+.. csv-table:: Zammad/Ruby version compatibility
+   :header: "Zammad", "Ruby"
    :widths: 20, 20
 
    "3.4+", "2.6.5"
@@ -79,17 +79,17 @@ While package install will insist on installing Elasticsearch, you can break tho
 
 The Elasticsearch support differs on the Elasticsearch and Zammad version you're using:
 
-.. csv-table:: Compatibility to Elasticsearch
-   :header: "Zammad version", "Supported Elasticsearch version"
+.. csv-table:: Zammad/Elasticsearch version compatibility
+   :header: "Zammad", "Elasticsearch"
    :widths: 20, 20
 
-   "3.4+", "5.5 up to 7.6.x"
-   "3.3", "2.4 up to 7.6.x"
-   "3.2", "2.4 up to 7.5.x"
-   "3.1", "2.4 up to 7.4.x"
-   "2.0 - 3.0", "2.4 up to 5.6.x"
+   "3.4+", "5.5–7.6"
+   "3.3", "2.4–7.6"
+   "3.2", "2.4–7.5"
+   "3.1", "2.4–7.4"
+   "2.0–3.0", "2.4–5.6"
 
-As Zammad indexes attachments, you'll need a plugin to do so - the names differ in between Elasticsearch versions:
+An Elasticsearch plugin is required to index the contents of email attachments:
 
-* Elasticsearch 5.5 with ``mapper-attachments`` plugin
-* Elasticsearch 5.6 up to 7.x with ``ingest-attachment`` plugin
+* ``mapper-attachments`` for Elasticsearch 5.5
+* ``ingest-attachment`` for Elasticsearch 5.6–7

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -9,9 +9,9 @@ If you want to install Zammad, you need the following software.
 Zammad requires Ruby. All required rubygems like ruby on rails are listed in the Gemfile.
 The following Ruby version is supported:
 
-* Ruby 2.5.5
+* Ruby 2.6.5
 
-.. warning:: We changed our Ruby dependency with Zammad 3.1. Earlier Zammad-Versions require Ruby 2.4.4.
+.. warning:: We changed our Ruby dependency with Zammad 3.4. Zammad 3.1 to 3.3 requires Ruby 2.5.5 - earlier versions require ruby 2.4.4.
 
 2. Package Dependencies
 =======================

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -77,8 +77,6 @@ While package install will insist on installing Elasticsearch, you can break tho
    We recommend using Elasticsearch, as it will boost the usuage of Zammad greatly!
 
 
-The Elasticsearch support differs on the Elasticsearch and Zammad version you're using:
-
 .. csv-table:: Zammad/Elasticsearch version compatibility
    :header: "Zammad", "Elasticsearch"
    :widths: 20, 20


### PR DESCRIPTION
This pull request mainly concentrates on adjusting requirenments.
This also includes a make over of how we communicate supported and/or required versions for ruby and elasticsearch. This has the benefit that some warning colors can disappear from the docs.

Beside of that I fiddled around with wording. :>

**Important:** We can't merge this before releasing 3.4 (or 1-2 hours before), as it might confuse users installing 3.3 at this moment.