### PR TITLE
Updated supported ES version for Zammad 3.4+

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -96,7 +96,7 @@ but search performance will be degraded, and some features will be disabled.
    :header: "Zammad", "Elasticsearch"
    :widths: 20, 20
 
-   "3.4+", "5.5–7.6"
+   "3.4+", "5.5–7.7"
    "3.3", "2.4–7.6"
    "3.2", "2.4–7.5"
    "3.1", "2.4–7.4"


### PR DESCRIPTION
Upon update of our on-premise Zammad 3.3 to 3.4 today, we also updated Elasticsearch from 7.5 to 7.7.1 on Debian 9 and it works perfectly with Zammad 3.4+.