### PR TITLE
WIP: Add requirement for restoration

### DIFF
--- a/appendix/backup-and-restore.rst
+++ b/appendix/backup-and-restore.rst
@@ -47,7 +47,8 @@ Before you migrate, please ensure the following requirenments are met:
 
 * The Zammad-Version on the destination system has to be the same or newer
 * You can't mix database types (postgresql or MySQL), as this needs conversion of your dump (which the script does not perform)
-  * We can offer you Dump-Migrations from MySQL to postgresql and postgresql to MySQL if need to change the databae for whatever reason, as a commercial service.
+  * We can offer you Dump-Migrations from MySQL to postgresql and postgresql to MySQL if need to change the 
+    database for whatever reason, as a commercial service.
 * Ensure you have enough free space on your drive (at least double as the size of your Dump!)
 
 If above requirenments are met, you can continue with restoring.

--- a/appendix/backup-and-restore.rst
+++ b/appendix/backup-and-restore.rst
@@ -50,6 +50,7 @@ Before you migrate, please ensure the following requirenments are met:
   * We can offer you Dump-Migrations from MySQL to postgresql and postgresql to MySQL if need to change the 
     database for whatever reason, as a commercial service.
 * Ensure you have enough free space on your drive (at least double as the size of your Dump!)
+* **If not source code installation:** You need a fresh Zammad installation
 
 If above requirenments are met, you can continue with restoring.
 


### PR DESCRIPTION
This commit fixes a typo `databae` to `database` and also adds another point to the reqiurements for non source code installations.

Last but not least it provides further hints for source code installations.

This PR is result of this issue:  https://github.com/zammad/zammad/issues/3160