### PR TITLE
Improved Performance Tuning.

### DIFF
--- a/appendix/configure-env-vars.rst
+++ b/appendix/configure-env-vars.rst
@@ -113,4 +113,4 @@ ZAMMAD_SESSION_JOBS_CONCURRENT
 
    .. code-block:: sh
 
-      $ zammad run rails r "p Sessions.list.count" 
+      $ zammad run rails r "p Sessions.list.uniq.count" 

--- a/appendix/configure-env-vars.rst
+++ b/appendix/configure-env-vars.rst
@@ -70,6 +70,8 @@ ZAMMAD_WEBSOCKET_PORT
 
 .. note:: Remember to update your webserver config to reflect any changes you make here.
 
+.. _performance_tuning:
+
 🎛️ Performance Tuning
 =====================
 

--- a/prerequisites/hardware.rst
+++ b/prerequisites/hardware.rst
@@ -30,7 +30,6 @@ performance will eventually degrade, leading to:
    * stale or out-of-sync search results, or
    * stale or out-of-sync ticket overviews.
 
-If upgrading your hardware configuration is not an option,
-you may see modest improvements by
-:doc:`setting certain environment variables </appendix/configure-env-vars>`,
+You may see modest improvements by
+:doc:`setting certain environment variables > Performance Tuning </appendix/configure-env-vars#performance-tuning>`,
 such as ``$WEB_CONCURRENCY`` or ``$ZAMMAD_SESSION_JOBS_CONCURRENT``.

--- a/prerequisites/hardware.rst
+++ b/prerequisites/hardware.rst
@@ -31,5 +31,5 @@ performance will eventually degrade, leading to:
    * stale or out-of-sync ticket overviews.
 
 You may see modest improvements by
-:doc:`setting certain environment variables > Performance Tuning </appendix/configure-env-vars#performance-tuning>`,
+:ref:`setting certain environment variables for Performance Tuning <performance_tuning>`,
 such as ``$WEB_CONCURRENCY`` or ``$ZAMMAD_SESSION_JOBS_CONCURRENT``.


### PR DESCRIPTION
Setting WEB_CONCURRENCY and ZAMMAD_SESSION_JOBS_CONCURRENT is not an option if hardware is not upgradable. It's always a option.

Enhanced link to certain settings via #performance-tuning anker.