### PR TITLE
Added section for running RSpec tests locally.

### DIFF
--- a/contributing/ci.rst
+++ b/contributing/ci.rst
@@ -22,3 +22,36 @@ Travis-CI
 
 .. image:: https://travis-ci.org/zammad/zammad.svg?branch=develop
    :target: https://travis-ci.org/zammad/zammad
+
+Local
+=====
+
+RSpec
+-----
+
+To run tests locally in the test environment, you need to first ensure the test DB is in the expected state:
+
+::
+
+  RAILS_ENV=test bundle exec rake db:drop db:create zammad:ci:test:prepare
+
+
+For tests that use compiled front end assets, make sure the latest state of the code is considered:
+
+::
+
+  RAILS_ENV=test bundle exec rake assets:precompile
+
+
+Finally, running a single test can be done via the following command:
+
+::
+
+  bundle exec rspec spec/system/ticket/zoom_spec.rb
+
+
+Note that it's also possible to run a specific test case by including the line number in the command:
+
+::
+
+  bundle exec rspec spec/system/ticket/zoom_spec.rb:1070


### PR DESCRIPTION
Section with required steps to run the new RSpec tests locally has been added. In the absence of a good developer manual, perhaps this should hopefully ease the pain for new contributors, considering new test cases are required for any changes. While it is possible to gather this information from the other maintainers, sometimes it's nice to find everything in one place.

(Based on the `master` branch, as previous [PR#162](https://github.com/zammad/zammad-documentation/pull/162) was erroneously based on `develop`.)

Reference: [zammad/zammad#3425 (comment)](https://github.com/zammad/zammad/pull/3425#issuecomment-785184981)