### PR TITLE
Maintenance: Fix wording for done-attribute (CTI-Log)

### DIFF
--- a/install/elasticsearch/indexed-attributes.rst
+++ b/install/elasticsearch/indexed-attributes.rst
@@ -734,7 +734,7 @@ CTI Log
      - Call direction
    * - done
      - ``true``, ``false``
-     - Defines if call is finished
+     - Defines if call displays as "to do" within UI
    * - duration_talking_time
      - ``27``
      - Call duration in seconds


### PR DESCRIPTION
This commit fixes wording for the `done` attribute which initially was incorrect. This might help admins, especially in reporting situations, to understand the scope of this attribute.