### PR TITLE
Raise minimum required database server versions

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -77,8 +77,8 @@ installed with the Zammad-Package.
 Zammad will store all content in a Database.
 You can choose between the following database servers:
 
-* MySQL 5.6+
-* MariaDB 10.0+
+* MySQL 5.7+
+* MariaDB 10.3+
 * PostgreSQL 9.1+
 
 .. note:: 


### PR DESCRIPTION
This pull request raises minimum database server versions to reflect current compatibilities.

MySQL: 5.6 → 5.7
MariaDB: 10.0 → 10.3

---

This reflects test environments and ensures e.g. big indexes working as intended.

@thorsteneckel Can you please have a look if that's okay from your end as well?

Thanks!