### PR TITLE
package.rst fix centos permissions fix

### DIFF
--- a/install/package.rst
+++ b/install/package.rst
@@ -195,7 +195,8 @@ Install Zammad
 
          .. code-block:: sh
 
-            chmod -R 755 /opt/zammad/public/
+            chown -R zammad /opt/zammad/public/
+            find /opt/zammad/public/ -type d -exec chmod +x {} \;
 
       .. tab:: OpenSUSE / SLES
 


### PR DESCRIPTION
There seems to be an issue with fix for the CentOS 8 permissions. 
I figured this is how it's supposed to be, not 100% sure about the `chown -R zammad /opt/zammad/public`. 
`find /opt/zammad/public/ -type d -exec chmod +x {} \;` basically sets the +x modifier only for directories, not all files.