### PR TITLE
Maintenance: Update keyserver to use for RVM

### DIFF
--- a/install/source.rst
+++ b/install/source.rst
@@ -109,7 +109,7 @@ older versions. A list of required versions can be found on the
               libxslt1-dev libyaml-0-2 autoconf automake libreadline-dev libyaml-dev libtool libgmp-dev libgdbm-dev libncurses5-dev\ 
               pkg-config libffi-dev libimlib2-dev gawk libsqlite3-dev sqlite3
 
-            $ gpg --keyserver hkp://keys.gnupg.net --recv-keys\ 
+            $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
               409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
             $ curl -L https://get.rvm.io | bash -s stable
 
@@ -128,7 +128,7 @@ older versions. A list of required versions can be found on the
             $ yum install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel ruby sqlite-devel\
               zlib-devel glibc-headers glibc-devel openssl-devel git imlib2 imlib2-devel
 
-            $ gpg --keyserver hkp://keys.gnupg.net --recv-keys\ 
+            $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
               409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
             $ curl -L https://get.rvm.io | bash -s stable
 
@@ -146,7 +146,7 @@ older versions. A list of required versions can be found on the
             $ zypper install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel sqlite3-devel\ 
               sqlite3 zlib-devel glibc-devel openssl-devel git imlib2 imlib2-devel gdbm-devel libyaml-devel
 
-            $ gpg --keyserver hkp://keys.gnupg.net --recv-keys\ 
+            $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
               409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
             $ curl -L https://get.rvm.io | bash -s stable
 


### PR DESCRIPTION
This might be a temporary solution as found on https://github.com/rvm/rvm/issues/5096 

RVM documentation currently is outdated and provides a solution that no longer works.