### PR TITLE
Changed instructions for acme.sh to webserver specific configuration

### DIFF
--- a/getting-started/configure-webserver.rst
+++ b/getting-started/configure-webserver.rst
@@ -74,15 +74,18 @@ The guide within the tabs below can help you jumping in.
 
             .. hint:: 
 
-               The most reliable way is to use the standalone method.
+               The most reliable way is to use the method for your webserver.
 
             First of all you'll need to issue your certificate.
             acme.sh will save this certificate to 
             ``/root/.acme.sh/<your-domain>/``
+            
+            Replace ``<webserver>`` in below command by either
+            ``apache`` or ``nginx`` and to match your setup, use ``standalone`` for other webservers.
 
             .. code-block:: sh
 
-               acme.sh --issue --standalone -d zammad.example.com
+               acme.sh --issue --<webserver> -d zammad.example.com
 
             It's not recommended to use the just stored certificates directly.
             Instead you should install the certificate to a directory of your 


### PR DESCRIPTION
Changed acme.sh to webserver specific configuration

When using nginx as Webserver for Zammad with letsencrypt and acme.sh previously `--standalone` was in the tutorial.

Default Zammad nginx configuration file can be found here https://github.com/zammad/zammad/blob/develop/contrib/nginx/zammad_ssl.conf
Relevant part:
```
server {
  listen 80;
  listen [::]:80;

  server_name example.com;

  # security - prevent information disclosure about server version
  server_tokens off;

  access_log /var/log/nginx/zammad.access.log;
  error_log /var/log/nginx/zammad.error.log;

  location /.well-known/ {
    root /var/www/html;
  }

  return 301 https://$server_name$request_uri;

}
```
This redirects http://yourzammadinstallation.org to https://yourzammadinstallation.org which makes perfectly sense.

However in standalone mode acme.sh needs port 80 to renew your certificate. Because it is blocked, you can't renew certificate with standalone mode. So using nginx mode solves this problem.

Try via `./acme.sh --cron --force --home "/root/.acme.sh"`
In `--standalone` this will give a error. It works however when initial config was via `acme.sh  --issue --nginx -d zammad.example.com `

Didn't test how apache behaves, but since there is a similar redirect to https in apache default zammand configuration https://github.com/zammad/zammad/blob/develop/contrib/apache2/zammad_ssl.conf it should give the same error when using `--standalone`