### PR TITLE
Enhance untar command for easier usage and enhance mysql information

### DIFF
--- a/install/source.rst
+++ b/install/source.rst
@@ -221,6 +221,21 @@ older versions. A list of required versions can be found on the
 
                   $ zypper install libmariadb-devel
 
+      Create database
+         While that's basically an easy step, you may want to create your
+         database as follows to minimize potential issues.
+
+         Below commands need adjustments to fit your environment.
+         Choose a safe password.
+
+         .. code-block:: sh
+
+            $ mysql
+            > create user 'zammad'@'localhost' identified by 'changeme';
+            > CREATE DATABASE zammad DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+            > GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, DROP, ALTER, CREATE TEMPORARY TABLES,\ 
+              LOCK TABLES ON zammad.* TO 'zammad'@'localhost';
+
 
       Install Gems for Zammad
          .. code-block:: sh

--- a/install/source/include-get-the-source.rst
+++ b/install/source/include-get-the-source.rst
@@ -5,6 +5,6 @@ or find the initial version at https://ftp.zammad.com.
 
    $ cd /opt
    $ wget https://github.com/zammad/zammad/archive/stable.tar.gz
-   $ tar -xzf stable.tar.gz -C zammad
+   $ tar -xzf stable.tar.gz --strip-components 1 -C zammad
    $ chown -R zammad:zammad zammad/
    $ rm -f stable.tar.gz

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -95,6 +95,14 @@ You can choose between the following database servers:
    * Set ``max_allowed_packet`` to a value larger than the default of 4 MB
      (64 MB+ recommended).
 
+   You may also want to consider the following settings for your MySQL server::
+
+      innodb_file_format = Barracuda
+      innodb_file_per_table = on
+      innodb_default_row_format = dynamic
+      innodb_large_prefix = 1
+      innodb_file_format_max = Barracuda
+
 5. Reverse Proxy
 ================
 


### PR DESCRIPTION
This pull request improves the unpack commands for github based tars (they contain a folder we don't want). This reduces load on administrators.

Additionally this PR enhances input on what MySQL servers need to provide to help users choosing that (not favored) way.