### PR TITLE
Update package.rst

### DIFF
--- a/install/package.rst
+++ b/install/package.rst
@@ -187,8 +187,7 @@ Install Zammad
 
          .. code-block:: sh
 
-            chown -R 644 /opt/zammad/public/
-            chmod -R +x /opt/zammad/public/
+            chmod -R 755 /opt/zammad/public/
 
       .. tab:: OpenSUSE / SLES
 


### PR DESCRIPTION
For the CentOS 8 installation,the chown command will change the group to 644 which is not a valid user group. I believe it was mistakenly typed in.
The proper permission would be 755 which required by nginx to read and execute the files under /opt/zammad/public/assets folder.