### PR TITLE
missing OpenSuSE dependency

### DIFF
--- a/install/source.rst
+++ b/install/source.rst
@@ -207,7 +207,7 @@ older versions. A list of required versions can be found on the
 
                .. code-block:: sh
 
-                  $ zypper install postgresql-devel
+                  $ zypper install postgresql-devel postgresql-server-devel
 
       Install Gems for Zammad
          .. code-block:: sh


### PR DESCRIPTION
the binary pg_config (required to build pg gem) is in the package postgresql-server-devel, added to the documentation.