### PR TITLE
Added a "config:get"-hint

### DIFF
--- a/appendix/configure-env-vars.rst
+++ b/appendix/configure-env-vars.rst
@@ -18,6 +18,9 @@ Use these environment variables to configure Zammad’s behavior at runtime.
       $ zammad config:set OPTION=value
       $ systemctl restart zammad
 
+      # get OPTION
+      $ zammad config:get OPTION
+
       # unset OPTION
       $ zammad config:unset OPTION
       $ systemctl restart zammad


### PR DESCRIPTION
Added a hint on how to get the current value of an option via "zammad config:get".