### PR TITLE
Update for Node.js 16 dependency of Zammad 5.2.

### DIFF
--- a/install/includes/nodejs/centos.rst
+++ b/install/includes/nodejs/centos.rst
@@ -1,9 +1,3 @@
 .. code-block:: sh
 
-   # CentOS 7
-   $ yum install centos-release-scl
-   $ yum install rh-nodejs12
-   $ echo "source scl_source enable rh-nodejs12" >> /etc/bashrc
-
-   # CentOS 8
-   $ yum install nodejs
+   $ curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash -

--- a/install/includes/nodejs/debian.rst
+++ b/install/includes/nodejs/debian.rst
@@ -2,10 +2,5 @@
 
    $ apt update
    $ apt install curl
-
-   # For Debian 10+
-   $ apt install nodejs
-
-   # For Debian 9+ (or if you want the most current version)
-   $ curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+   $ curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
    $ apt install nodejs

--- a/install/includes/nodejs/suse.rst
+++ b/install/includes/nodejs/suse.rst
@@ -1,3 +1,3 @@
 .. code-block:: sh
 
-   $ zypper install nodejs
+   $ zypper install nodejs16

--- a/install/includes/nodejs/ubuntu.rst
+++ b/install/includes/nodejs/ubuntu.rst
@@ -2,10 +2,5 @@
 
    $ apt update
    $ apt install curl
-
-   # For Ubuntu 20+
-   $ apt install nodejs
-
-   # For Ubuntu 16+ (or if you want the most current version)
-   $ curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+   $ curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
    $ apt install nodejs

--- a/install/package.rst
+++ b/install/package.rst
@@ -1,11 +1,11 @@
 Install from package
 ********************
 
-.. note:: 
+.. note::
 
-   | Please ensure to meet Zammads :doc:`/prerequisites/software` requirements 
+   | Please ensure to meet Zammads :doc:`/prerequisites/software` requirements
      before hand.
-   | This page expects administrative permissions, this is why ``sudo`` is 
+   | This page expects administrative permissions, this is why ``sudo`` is
      not used.
 
 Prerequisites
@@ -14,7 +14,7 @@ Prerequisites
 Additional software dependencies
 --------------------------------
 
-In addition to already mentioned :ref:`Package dependencies <package_dependencies>`, 
+In addition to already mentioned :ref:`Package dependencies <package_dependencies>`,
 some operating systems may require additional packages if not already installed.
 
 .. tabs::
@@ -22,7 +22,7 @@ some operating systems may require additional packages if not already installed.
    .. tab:: Ubuntu / Debian
 
       .. code-block:: sh
-      
+
          $ apt install curl apt-transport-https gnupg
 
    .. tab:: CentOS
@@ -34,43 +34,16 @@ some operating systems may require additional packages if not already installed.
          # CentOS 7
          $ yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 
-(optional) Node.js
-~~~~~~~~~~~~~~~~~~
-
-Zammad requires Node.js for compiling its assets.
-Package installations by default come shipped with assets compiled already.
-
-You'll only have to install ``Node.js`` in case you're going to change
-``CSS`` or ``JS`` files.
-
-.. tabs::
-
-   .. tab:: Ubuntu
-
-      .. include:: /install/includes/nodejs/ubuntu.rst
-
-   .. tab:: Debian
-
-      .. include:: /install/includes/nodejs/debian.rst
-
-   .. tab:: CentOS
-
-      .. include:: /install/includes/nodejs/centos.rst
-
-   .. tab:: OpenSUSE / SLES
-
-      .. include:: /install/includes/nodejs/suse.rst
-
 .. include:: /install/includes/prerequisites.rst
 
 Add Repository and install Zammad
 =================================
 
-.. hint:: 
+.. hint::
 
-   If you want to use MySQL instead of PostgreSQL, it's usually enough to have 
-   the MySQL server installed on your system already. Some installation 
-   managers can't differentiate and still install Zammad with PostgreSQL. In 
+   If you want to use MySQL instead of PostgreSQL, it's usually enough to have
+   the MySQL server installed on your system already. Some installation
+   managers can't differentiate and still install Zammad with PostgreSQL. In
    that case, you'll have to adapt manually (out of scope of this documentation).
 
 Add Repository
@@ -189,8 +162,8 @@ Install Zammad
             # general
             $ yum install zammad
 
-         Due to an `issue <https://github.com/crohr/pkgr/issues/165>`_ with 
-         packager.io on CentOS 8 you'll need to correct file permissions for 
+         Due to an `issue <https://github.com/crohr/pkgr/issues/165>`_ with
+         packager.io on CentOS 8 you'll need to correct file permissions for
          public files.
 
          .. code-block:: sh
@@ -200,7 +173,7 @@ Install Zammad
       .. tab:: OpenSUSE / SLES
 
          .. code-block:: sh
-         
+
             $ zypper ref
             $ zypper install zammad
 

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -179,7 +179,12 @@ You can choose between the following database servers:
 2.5. Node.js
 ------------
 
-.. note:: This soft dependency was introduced with Zammad 5.0.
+.. note::
+
+   | This soft dependency was introduced with Zammad 5.0.
+   | Package installations come pre-bundled with the correct NodeJS version.
+     Unless you require NodeJS on your machine for other projects, a manual
+     installation *is not* required.
 
 Node.js is required for asset compiling.
 

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -21,16 +21,16 @@ requirements for your clients. This ensures that Zammad works as expected.
    * - Opera 69+
      - (based on Chromium 83)
    * - Microsoft Internet Explorer 11
-     - 
+     -
    * - Safari 11
-     - 
+     -
 
 .. note::
 
    | Zammad heavily uses Javascript which makes it a hard requirement.
    |
    | Browser addons that hook into page content may interfere with Zammads function
-     which is not a bug. 
+     which is not a bug.
    | Google Chromes translation module is known to do
      odd things to especially state names. Use Zammads internal translations
      instead.
@@ -195,7 +195,8 @@ Node.js is required for asset compiling.
    :header: "Zammad", "Node.js"
    :widths: 20, 20
 
-   "5.0+", "10.0+"
+   "5.2+", "16.0+"
+   "5.0 - 5.1", "10.0+"
 
 2.6. Reverse Proxy
 ------------------


### PR DESCRIPTION
- Installation instructions changed to use LTS versions of Node.js rather than the most recent.
- Removed Node.js installation instructions for package installations as Node.js gets bundled by packager.io.