### PR TITLE
Maintenance: Add strict warning that Ubuntu 22 is not yet supported

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -111,6 +111,12 @@ Below you can find all distributions Zammad provides packages for.
    If you're not running a docker-compose or package installation please
    consider changing to a different distribution that's supported.
 
+.. danger:: **☠️ Incompatibility warning for Ubuntu 22.04 LTS ☠️**
+
+   Please note that due to Ubuntu's dependencies, Zammad currently **is not**
+   compatible to Ubuntu 22. This affects *all installation types* except
+   for docker style installations!
+
 .. note:: **🤓 What about my specific distribution?! It's so cool!**
 
    If you distribution is not listed, you can still install Zammad.


### PR DESCRIPTION
This adds a clear warning that Ubuntu 22 is not yet supported due to its dependencies that Zammad currently does not fulfill.

JFI: Can safely be merged into the destination branch configured if everything is good to go. ✌️ 