### PR TITLE
Update deprecated 'Cache.clear' calls to 'Rails.cache.clear'.

### DIFF
--- a/appendix/backup-and-restore/clear-the-cache.include.rst
+++ b/appendix/backup-and-restore/clear-the-cache.include.rst
@@ -1,3 +1,3 @@
 .. code-block:: sh
 
-   $ zammad run rails r "Cache.clear"
+   $ zammad run rails r "Rails.cache.clear"

--- a/install/update.rst
+++ b/install/update.rst
@@ -1,7 +1,7 @@
 Updating Zammad
 ***************
 
-.. note:: 
+.. note::
 
    🙈 Better safe than sorry
       Before updating to a new version, please have a look into the
@@ -24,7 +24,7 @@ Updating Zammad
       version of Zammad being 5.1 and your instance being on Zammad 2.4, your
       path would look like so:
       ``2.4`` → ``3.0`` → ``4.0`` → ``5.0`` → ``latest stable (5.1)``
- 
+
 .. _release notes: https://zammad.com/en/releases
 .. _Zammad hosting: https://zammad.com/en/pricing
 
@@ -33,7 +33,7 @@ Updating Zammad
    .. tab:: Package
 
       Step 1: Ensure dependencies
-         Before proceeding, double-check that your system environment matches 
+         Before proceeding, double-check that your system environment matches
          :doc:`Zammad’s requirements </prerequisites/software>`.
 
       Step 2: Stop Zammad
@@ -47,7 +47,7 @@ Updating Zammad
       Step 4: Clear Zammad cache
          .. code-block:: sh
 
-            $ zammad run rails r "Cache.clear"
+            $ zammad run rails r "Rails.cache.clear"
 
       Step 5: Update Zammad
          .. tabs::
@@ -74,13 +74,13 @@ Updating Zammad
 
          .. warning::
 
-            The package comes with maintenance scripts that will run regular 
+            The package comes with maintenance scripts that will run regular
             tasks during updates for you.
 
             | **However**
-            | Do not run Zammad updates unattended and **always** have a look 
-              on the outputs these helper scripts generate. Ignoring said 
-              output may lead to incomplete updates that may corrupt data or 
+            | Do not run Zammad updates unattended and **always** have a look
+              on the outputs these helper scripts generate. Ignoring said
+              output may lead to incomplete updates that may corrupt data or
               lead to issues you find *way too late*.
 
       Step 6: Run required extra steps
@@ -100,12 +100,12 @@ Updating Zammad
          :ref:`source-install-systemd-reference`!
 
       Step 1: Ensure dependencies
-         Before proceeding, double-check that your system environment matches 
+         Before proceeding, double-check that your system environment matches
          :doc:`Zammad’s requirements </prerequisites/software>`.
 
          .. tip:: **🤓 Ruby version changed?**
 
-            Please see 
+            Please see
             :ref:`Installation part of source code installation <source_dependency_installation>`
 
       Step 2: Stop Zammad and Clear Zammad cache
@@ -113,7 +113,7 @@ Updating Zammad
 
          .. code-block:: sh
 
-            $ rails r "Cache.clear"
+            $ rails r "Rails.cache.clear"
 
       Step 3: Download Zammad to your system
          .. include:: /install/source/include-get-the-source.rst
@@ -166,17 +166,17 @@ Updating Zammad
 
    .. tab:: Docker Compose
 
-      .. warning:: 
+      .. warning::
 
          ⚠️ **Updates may require extra steps or introduce breaking changes.**
 
-         Always check the 
-         `upgrade notes <https://github.com/zammad/zammad-docker-compose#upgrading>`_ 
+         Always check the
+         `upgrade notes <https://github.com/zammad/zammad-docker-compose#upgrading>`_
          first.
 
       .. note:: **🙀 Incomplete documentation**
 
-         Sorry, but this documentation part is outdated. 
+         Sorry, but this documentation part is outdated.
          We will rework this part later, but can't tell when yet.
 
          Please feel welcome to provide a pull request if you find spare time!
@@ -212,15 +212,15 @@ Updating Elasticsearch
 
 .. warning::
 
-   Updating Elasticsearch **does not** automatically update it's plugins! 
-   This usually isn't an issue if Zammad is being updated right after 
+   Updating Elasticsearch **does not** automatically update it's plugins!
+   This usually isn't an issue if Zammad is being updated right after
    Elasticsearch.
 
-If you want to upgrade your elasticsearch installation, please take a look at the 
+If you want to upgrade your elasticsearch installation, please take a look at the
 `elasticsearch documentation <https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html>`_
 as it will have the most current information for you.
 
-If, for whatever reason, you need to rebuild your search index after upgrading, 
+If, for whatever reason, you need to rebuild your search index after upgrading,
 use:
 
 .. code-block:: sh
@@ -233,14 +233,14 @@ use:
    You will still be able to use the old method until Zammad 6, however, will
    receive a deprecation warning.
 
-.. warning:: 
+.. warning::
 
-   This step may fail if Zammad is under heavy load: Elasticsearch locks the 
-   indices from deletion if you're pumping in new data, like receiving a new 
+   This step may fail if Zammad is under heavy load: Elasticsearch locks the
+   indices from deletion if you're pumping in new data, like receiving a new
    ticket. (This only applies to single-node deployments, not clusters.)
-   
+
    If it does, try killing Zammad first::
-   
+
       $ systemctl stop zammad
       $ zammad run rake zammad:searchindex:rebuild
       $ systemctl start zammad

--- a/migration/includes/commands-after-migration.include.rst
+++ b/migration/includes/commands-after-migration.include.rst
@@ -4,4 +4,4 @@ After the import has finished, run the following commands
 
       $ Setting.set('import_mode', false)
       $ Setting.set('system_init_done', true)
-      $ Cache.clear
+      $ Rails.cache.clear


### PR DESCRIPTION
This will avoid deprecation warnings in the logs and avoid problems with Zammad 6.