### PR TITLE
Fix typo and added clarification

### DIFF
--- a/appendix/backup-and-restore/migrate-hosts.rst
+++ b/appendix/backup-and-restore/migrate-hosts.rst
@@ -81,8 +81,8 @@ Step 6: Backup!
       :doc:`configuration page </appendix/backup-and-restore/configuration>`.
 
 Step 7: Transfer your backup files
-   You'll find the backup location within the ``conf`` file on the backup
-   directory. Make sure to adjust the backup configuration on the destination
+   You'll find the backup location within the ``config`` file on the backup
+   directory (`/opt/zammad/contrib/backup`). Make sure to adjust the backup configuration on the destination
    host according to our
    :doc:`configuration page </appendix/backup-and-restore/configuration>`
    to provide the correct backup file directory.


### PR DESCRIPTION
Replaced `conf` with `config` as it was not the same name as described on the backup-and-restore configuration page https://docs.zammad.org/en/latest/appendix/backup-and-restore/configuration.html
That confused me as I thought maybe there was another file I was missing.
Also added the path of were this `config` file is located