### PR TITLE
Maintenance: Change to the FTP download URL now that we have continuous delivery for source archives

### DIFF
--- a/install/source/include-get-the-source.rst
+++ b/install/source/include-get-the-source.rst
@@ -1,5 +1,5 @@
-Get the latest stable release of Zammad `here <https://github.com/zammad/zammad/archive/stable.tar.gz>`_,
-or find the initial version at https://ftp.zammad.com.
+Get the latest stable release of Zammad `here <https://ftp.zammad.com/zammad-latest.tar.gz>`_.
+This file will be updated whenever new bug-fixes are applied, so you can update from this URL regularly.
 
 .. code-block:: sh
 

--- a/install/source/include-get-the-source.rst
+++ b/install/source/include-get-the-source.rst
@@ -4,7 +4,7 @@ This file will be updated whenever new bug-fixes are applied, so you can update 
 .. code-block:: sh
 
    $ cd /opt
-   $ wget https://github.com/zammad/zammad/archive/stable.tar.gz
-   $ tar -xzf stable.tar.gz --strip-components 1 -C zammad
+   $ wget https://ftp.zammad.com/zammad-latest.tar.gz
+   $ tar -xzf zammad-latest.tar.gz --strip-components 1 -C zammad
    $ chown -R zammad:zammad zammad/
-   $ rm -f stable.tar.gz
+   $ rm -f zammad-latest.tar.gz


### PR DESCRIPTION
`zammad-latest.*` on FTP will be updated by CI whenever a commit is applied to `stable`. Let's update the docs for this as well.