### PR TITLE
Include a hint that Redis will be a regulard dependency from Zammad 6.0 onwards.

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -289,11 +289,6 @@ An Elasticsearch plugin is required to index the contents of email attachments:
 
    We consider this topic as :ref:`performance_tuning`.
 
-.. hint:: **Redis will become a regular dependency in Zammad 6**
-
-   Starting with Zammad 6.0, Redis will be required to operate Zammad,
-   not just as a performance optimization.
-
 2.8.1 Redis
 ~~~~~~~~~~~
 
@@ -305,6 +300,11 @@ An Elasticsearch plugin is required to index the contents of email attachments:
          Configuration and installation is out of our scope.
          Please follow the official vendor guides and ensure to have a
          tight security on your installation.
+
+      .. hint:: **Redis will become a regular dependency in Zammad 6**
+
+         Starting with Zammad 6.0, Redis will be required to operate Zammad,
+         not just as a performance optimization.
 
 2.8.2 Memcached
 ~~~~~~~~~~~~~~~

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -289,6 +289,10 @@ An Elasticsearch plugin is required to index the contents of email attachments:
 
    We consider this topic as :ref:`performance_tuning`.
 
+.. hint:: **Redis will become a regular dependency in Zammad 6**
+
+   Starting with Zammad 6.0, Redis will be required to operate Zammad,
+   not just as a performance optimization.
 
 2.8.1 Redis
 ~~~~~~~~~~~


### PR DESCRIPTION
There will also be announcements on other channels, but the documentation should also give a hint about it.

This can be merged after review, don't need to wait for Zammad 5.4.

Not sure if we can/need to make this more prominent on the software requirements page somehow.