### PR TITLE
DRAFT v5.4: Fixes #4437 - DataPrivacy tasks never are cleaned up.

### DIFF
--- a/appendix/privacy.rst
+++ b/appendix/privacy.rst
@@ -52,6 +52,9 @@ User sessions
    Session information includes IP address (and possibly geographic location), browser,
    time of original login, and time of last visit.
 
+Data Privacy Tasks
+   Each entry in the data privacy task list is automatically deleted after 6 months.
+
 External Services
 =================
 


### PR DESCRIPTION
Related proposal MR for https://github.com/zammad/zammad/issues/4437 fix