### PR TITLE
Fixes invalid endpoint documentation

### DIFF
--- a/api/organization.rst
+++ b/api/organization.rst
@@ -328,7 +328,7 @@ Required permission: ``admin.organization``
 .. _Data Privacy:
    https://admin-docs.zammad.org/en/latest/system/data-privacy.html
 
-``DELETE``-Request sent: ``/api/v1/organization/{id}``
+``DELETE``-Request sent: ``/api/v1/organizations/{id}``
 
 Response:
 

--- a/appendix/configure-env-vars.rst
+++ b/appendix/configure-env-vars.rst
@@ -75,7 +75,7 @@ RAILS_LOG_TO_STDOUT
 ZAMMAD_BIND_IP
    The IP address that the web server is bound to.
 
-   Default: ``0.0.0.0``
+   Default: ``127.0.0.1``
 
 ZAMMAD_RAILS_PORT
    The port that the web server is exposed on.


### PR DESCRIPTION
The route to delete an organization is ``/api/v1/organizations/{id}`` instead of ``/api/v1/organization/{id}``