### PR TITLE
Add websockets port to software requirements docs

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -45,7 +45,7 @@ requirements for your clients. This ensures that Zammad works as expected.
 1.2. Network requirements
 -------------------------
 
-Zammad uses web sockets. Some application firewalls may filter these
+Zammad uses web sockets (listening on port ``6042``). Some application firewalls may filter these
 connections. This may lead to decreased browser performance.
 
 There's a fallback to Ajax which  causes a higher application server load


### PR DESCRIPTION
I was missing the port that is used for websockets connections on this documentation page. Is `6042` the correct port? I found it on [adjusting the webserver configuration](https://docs.zammad.org/en/latest/getting-started/configure-webserver.html?highlight=websockets#adjusting-the-webserver-configuration) (local testing or other proxy servers).