### PR TITLE
Maintenance: Add CI pipeline based on Github workflows.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,100 @@
+name: Documentation
+
+# Controls when the workflow will run.
+on:
+
+  # Allow the workflow to be reusable.
+  workflow_call:
+    inputs:
+      docs_path:
+        description: Path to the documentation directory, relative to the repository root.
+        required: false
+        default: .
+        type: string
+      system_dependencies:
+        description: Optional list of system dependencies to install via `apt` command, separated by spaces.
+        required: false
+        default: gettext
+        type: string
+      python_version:
+        description: The version of Python binary to use.
+        required: false
+        default: '3.7'
+        type: string
+      requirements_path:
+        description: Path to the `requirements.txt`, relative to the repository root.
+        required: false
+        default: requirements.txt
+        type: string
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 50
+
+    - name: Install System Dependencies
+      shell: bash -eux {0}
+      run: |
+        sudo apt-get -q -y update
+        sudo apt-get -q -y install ${{ inputs.system_dependencies }}
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python_version }}
+
+    - name: Install Python Dependencies
+      shell: bash -eux {0}
+      run: |
+        python -m pip install --upgrade --no-cache-dir pip setuptools
+        python -m pip install --upgrade --no-cache-dir pillow mock==1.0.1 'alabaster>=0.7,<0.8,!=0.7.5' commonmark==0.9.1 recommonmark==0.5.0 'sphinx<2' 'sphinx-rtd-theme<0.5' 'readthedocs-sphinx-ext<2.3' 'jinja2<3.1.0'
+        python -m pip install --exists-action=w --no-cache-dir -r ${{ inputs.requirements_path }}
+
+    - name: Check RST Syntax
+      shell: bash -eux {0}
+      run: |
+        python -m pip install --upgrade --no-cache-dir 'rstcheck[sphinx]'
+        rstcheck --warn-unknown-settings --recursive .
+
+    - name: Check Translation Sources
+      shell: bash -eux {0}
+      run: |
+        if [[ -d "locale" ]]; then
+          make gettext
+          if git status --short | grep " M locale/"; then
+            echo "Translation sources are out-of-date, please update them with `make gettext`."
+            exit 1
+          fi
+        fi
+
+    - name: Debug Configuration
+      shell: bash -eux {0}
+      run: cat conf.py
+
+    - name: Build Documentation
+      shell: bash -eux {0}
+      run: |
+        cd ${{ inputs.docs_path }}
+        python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
+        python -m sphinx -T -E -b epub -d _build/doctrees -D language=en . _build/epub
+
+    - name: Compute short SHA
+      id: sha
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Upload html Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: html-${{ steps.sha.outputs.sha_short }}
+        path: ${{ inputs.docs_path }}/_build/html/
+
+    - name: Upload epub Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: epub-${{ steps.sha.outputs.sha_short }}
+        path: ${{ inputs.docs_path }}/_build/epub/*.epub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+# Controls when the workflow will run.
+on:
+  # Trigger the workflow on all pushes, except on tag creation.
+  push:
+    branches:
+      - main
+      - pre-release
+    tags-ignore:
+      - "**"
+
+  # Trigger the workflow on all pull requests.
+  pull_request: ~
+
+  # Allow workflow to be dispatched on demand.
+  workflow_dispatch: ~
+
+jobs:
+  docs:
+    name: Documentation
+    uses: ./.github/workflows/docs.yml

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,6 @@
+[rstcheck]
+report_level=WARNING
+ignore_directives =
+  tabs
+ignore_languages=
+  json


### PR DESCRIPTION
Job example (from the fork): [main](https://github.com/dvuckovic/zammad-documentation/actions/runs/5666763737)