### PR TITLE
Switch to Node 18 requirement and drop unsupported linux distributions.

### DIFF
--- a/install/includes/firewall-and-selinux.rst
+++ b/install/includes/firewall-and-selinux.rst
@@ -29,7 +29,7 @@ Firewall
 
    .. note::
 
-      Below only covers the distributions default firewall.
+      Below only covers the distribution's default firewall.
       It may not cover your case.
 
 .. tabs::

--- a/install/includes/firewall-and-selinux.rst
+++ b/install/includes/firewall-and-selinux.rst
@@ -21,18 +21,15 @@ SELinux
 
    .. tab:: OpenSUSE
 
-      SELinux support on SUSE seems to be in early state, at least for SLES 12 
-      (and Leap 42.x). This is why we won't cover it in this documentation.
-
-      See `the documentation <https://doc.opensuse.org/documentation/leap/archive/42.3/security/html/book.security/cha.selinux.html>`_ 
-      for more input if you still wish to continue.
+      See `the documentation <https://doc.opensuse.org/documentation/leap/security/html/book-security/cha-selinux.html>`_
+      for more input if you wish to continue.
 
 Firewall
 --------
 
-   .. note:: 
+   .. note::
 
-      Below only covers the distributions default firewall. 
+      Below only covers the distributions default firewall.
       It may not cover your case.
 
 .. tabs::
@@ -48,13 +45,13 @@ Firewall
 
    .. tab:: Debian
 
-      .. warning:: 
+      .. warning::
 
-         We're covering ``nftables`` in this part - iptables is discouraged 
-         starting from Debian 10 (Buster). 
+         We're covering ``nftables`` in this part - iptables is discouraged
+         starting from Debian 10 (Buster).
          Our example uses the ``input`` chain, yours may be a different one!
 
-      Add the following lines to ``/etc/nftables.conf`` or your specific rule 
+      Add the following lines to ``/etc/nftables.conf`` or your specific rule
       file. Ensure to add these lines to your input-chain.
 
       .. code-block::
@@ -63,7 +60,7 @@ Firewall
          tcp dport { http, https } accept
          udp dport { http, https } accept
 
-      The result should look like the following. Keep in mind that your 
+      The result should look like the following. Keep in mind that your
       enviroment could require different / more rules.
 
       .. code-block::
@@ -102,8 +99,8 @@ Firewall
 
    .. tab:: OpenSUSE
 
-      If your system does not yet know webserver rules, you can add a new one 
-      for your firewall by creating the file 
+      If your system does not yet know webserver rules, you can add a new one
+      for your firewall by creating the file
       ``/etc/sysconfig/SuSEfirewall2.d/services/webserver`` with this content:
 
       .. code-block::
@@ -116,9 +113,9 @@ Firewall
          # space separated list of allowed UDP ports
          UDP="http https"
 
-      After that locate ``FW_CONFIGURATIONS_EXT`` within 
-      ``/etc/sysconfig/SuSEfirewall2`` and add the option ``webserver`` to the 
-      list. The list is seperated by spaces. 
+      After that locate ``FW_CONFIGURATIONS_EXT`` within
+      ``/etc/sysconfig/SuSEfirewall2`` and add the option ``webserver`` to the
+      list. The list is seperated by spaces.
       You may require a different zone, above covers the external zone.
 
       Now ensure to restart the firewall service.
@@ -129,5 +126,5 @@ Firewall
 
    .. tab:: other
 
-      If we didn't cover your distribution or firewall in question, ensure to 
+      If we didn't cover your distribution or firewall in question, ensure to
       open ports ``80`` and ``443`` (TCP & UDP) beside of the ports you need.

--- a/install/includes/postgres-dependencies.rst
+++ b/install/includes/postgres-dependencies.rst
@@ -11,9 +11,6 @@ Install PostgreSQL Dependencies
 
             .. code-block:: sh
 
-                # CentOS 7
-                $ yum install postgresql14-libs postgresql14-devel
-
                 # CentOS 8
                 $ yum install postgresql-libs postgresql-devel
 
@@ -29,8 +26,3 @@ Install Gems for Zammad
         $ su - zammad
         $ bundle config set without "test development mysql"
         $ bundle install
-
-        # CentOS 7 users - above command might fail, run the following
-        # command and repeat above bundle install.
-        # Adjust pg_config path according to your environment
-        $ gem install pg -v '1.2.3' -- --with-pg-config=/usr/pgsql-14/bin/pg_config

--- a/install/includes/postgres-installation.rst
+++ b/install/includes/postgres-installation.rst
@@ -13,13 +13,6 @@
 
       .. code-block:: sh
 
-         # CentOS 7
-         $ yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-         $ yum install postgresql15-server postgresql15-contrib
-         $ postgresql-15-setup initdb
-         $ systemctl start postgresql-15
-         $ systemctl enable postgresql-15
-
          # CentOS 8
          $ yum install postgresql-server postgresql-contrib
          $ postgresql-setup initdb

--- a/install/package.rst
+++ b/install/package.rst
@@ -41,9 +41,6 @@ some operating systems may require additional packages if not already installed.
 
          $ yum install wget epel-release
 
-         # CentOS 7
-         $ yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-
 .. include:: /install/includes/prerequisites.rst
 
 Add Repository and install Zammad
@@ -59,12 +56,6 @@ Add Repository
 
                $ curl -fsSL https://dl.packager.io/srv/zammad/zammad/key | \
                  gpg --dearmor | tee /etc/apt/trusted.gpg.d/pkgr-zammad.gpg> /dev/null
-
-         Ubuntu 18.04
-            .. code-block:: sh
-
-               $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/pkgr-zammad.gpg] https://dl.packager.io/srv/deb/zammad/zammad/stable/ubuntu 18.04 main"| \
-                  tee /etc/apt/sources.list.d/zammad.list > /dev/null
 
          Ubuntu 20.04
             .. code-block:: sh
@@ -86,12 +77,6 @@ Add Repository
                $ curl -fsSL https://dl.packager.io/srv/zammad/zammad/key | \
                  gpg --dearmor | tee /etc/apt/trusted.gpg.d/pkgr-zammad.gpg> /dev/null
 
-         Debian 10
-            .. code-block:: sh
-
-               $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/pkgr-zammad.gpg] https://dl.packager.io/srv/deb/zammad/zammad/stable/debian 10 main"| \
-                  tee /etc/apt/sources.list.d/zammad.list > /dev/null
-
          Debian 11
             .. code-block:: sh
 
@@ -111,12 +96,6 @@ Add Repository
 
                $ rpm --import https://dl.packager.io/srv/zammad/zammad/key
 
-         RHEL 7 / CentOS 7
-            .. code-block:: sh
-
-               $ wget -O /etc/yum.repos.d/zammad.repo \
-               https://dl.packager.io/srv/zammad/zammad/stable/installer/el/7.repo
-
          RHEL 8 / CentOS 8
             .. code-block:: sh
 
@@ -125,22 +104,10 @@ Add Repository
 
       .. tab:: OpenSUSE / SLES
 
-         Remove obsolete Let's Encrypt CA (SLES12 and openSUSE 42.x only)
-            .. code-block:: sh
-
-               $ rm /usr/share/pki/trust/DST_Root_CA_X3.pem
-               $ update-ca-certificates
-
          Install Repository Key
             .. code-block:: sh
 
                $ rpm --import https://dl.packager.io/srv/zammad/zammad/key
-
-         SLES 12 / openSUSE 42.x
-            .. code-block:: sh
-
-               $ wget -O /etc/zypp/repos.d/zammad.repo \
-               https://dl.packager.io/srv/zammad/zammad/stable/installer/sles/12.repo
 
          SLES 15 / openSUSE 15.x
             .. code-block:: sh
@@ -161,12 +128,6 @@ Install Zammad
       .. tab:: CentOS
 
          .. code-block:: sh
-
-            # CentOS 7
-            $ yum install postgresql14-server
-            $ postgresql-14-setup initdb
-            $ systemctl start postgresql-14
-            $ systemctl enable postgresql-14
 
             # general
             $ yum install zammad

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -106,19 +106,12 @@ Below you can find all distributions Zammad provides packages for.
    :header: "Distribution", "Versions"
    :widths: 20, 20
 
-   "CentOS / RHEL", "7 & 8"
-   "Debian", "10, 11 & 12"
-   "OpenSuSE / SLES", "Leap 42.3 / 12; Leap 15.x / 15"
-   "Ubuntu", "18.04, 20.04 & 22.04"
-
-.. warning:: **⚠ Changes with Zammad 6.2**
-
-   Zammad 6.2 will not provide packages for Debian 10, Ubuntu 18.04, and SLES 12. Users of these distributions are encouraged to update to more recent versions like Debian 12, Ubuntu 22.04, and SLES 15.
+   "CentOS / RHEL", "8"
+   "Debian", "11 & 12"
+   "OpenSuSE / SLES", "Leap 15.x / 15"
+   "Ubuntu", "20.04 & 22.04"
 
 .. warning:: **⚠ SuSE users be aware**
-
-   Due to the age of SLES12 / Leap 42.3 you may no longer be able to satisfy
-   all (soft) dependencies of Zammad.
 
    Note that SuSE Tumbleweed *does not* meet Zammad requirements and thus
    *is not* supported!
@@ -213,7 +206,8 @@ Node.js is required for asset compiling.
    :header: "Zammad", "Node.js"
    :widths: 20, 20
 
-   "5.2+", "16.0+"
+   "6.2+", "18.0+"
+   "5.2 - 6.1", "16.0+"
    "5.0 - 5.1", "10.0+"
 
 2.6. Reverse Proxy


### PR DESCRIPTION
- Change to Node 18.
- Drop Debian 10, Ubuntu 18, CentOS7, and SLES 12 which are unsupported after deprecation with Zammad 6.1.