### PR TITLE
Remove timeout option from db connection configuration 

### DIFF
--- a/install/source.rst
+++ b/install/source.rst
@@ -199,7 +199,6 @@ file could look like. Please also have a look at
          adapter: postgresql
          database: zammad
          pool: 50
-         timeout: 5000
          encoding: utf8
          username: zammad
          password: changeme


### PR DESCRIPTION
This is related to https://github.com/zammad/zammad/pull/4883

The postgresql connection adapter does not support a `timeout` option.