### PR TITLE
Remove sqlite3-related packages from recommended packages

### DIFF
--- a/install/source.rst
+++ b/install/source.rst
@@ -87,7 +87,7 @@ older versions. A list of required versions can be found on the
 
             $ apt install curl git patch build-essential bison zlib1g-dev libssl-dev libxml2-dev libxml2-dev autotools-dev\ 
               libxslt1-dev libyaml-0-2 autoconf automake libreadline-dev libyaml-dev libtool libgmp-dev libgdbm-dev libncurses5-dev\ 
-              pkg-config libffi-dev libimlib2-dev gawk libsqlite3-dev sqlite3 software-properties-common
+              pkg-config libffi-dev libimlib2-dev gawk software-properties-common
 
             $ apt-add-repository -y ppa:rael-gc/rvm
             $ apt update
@@ -109,7 +109,7 @@ older versions. A list of required versions can be found on the
 
             $ apt install curl git patch build-essential bison zlib1g-dev libssl-dev libxml2-dev libxml2-dev autotools-dev\ 
               libxslt1-dev libyaml-0-2 autoconf automake libreadline-dev libyaml-dev libtool libgmp-dev libgdbm-dev libncurses5-dev\ 
-              pkg-config libffi-dev libimlib2-dev gawk libsqlite3-dev sqlite3
+              pkg-config libffi-dev libimlib2-dev gawk
 
             $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
               409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
@@ -130,7 +130,7 @@ older versions. A list of required versions can be found on the
          .. code-block:: sh
 
             $ yum install epel-release
-            $ yum install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel ruby sqlite-devel\
+            $ yum install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel ruby\
               zlib-devel glibc-headers glibc-devel openssl-devel git imlib2 imlib2-devel
 
             $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
@@ -151,8 +151,8 @@ older versions. A list of required versions can be found on the
       Install RVM
          .. code-block:: sh
 
-            $ zypper install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel sqlite3-devel\ 
-              sqlite3 zlib-devel glibc-devel openssl-devel git imlib2 imlib2-devel gdbm-devel libyaml-devel
+            $ zypper install patch autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline-devel\
+              zlib-devel glibc-devel openssl-devel git imlib2 imlib2-devel gdbm-devel libyaml-devel
 
             $ gpg --keyserver keyserver.ubuntu.com --recv-keys\ 
               409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB


### PR DESCRIPTION
The Zammad `Gemfile` and `Gemfile.lock` don't reference any sqlite-related gems anymore, those packages are probably not needed anymore.