### PR TITLE
Improve docker compose manual download instructions.

### DIFF
--- a/install/docker-compose.rst
+++ b/install/docker-compose.rst
@@ -62,8 +62,9 @@ Step 1: Clone GitHub repo
 
 .. hint::
 
-   If cloning is too much of a hassle, it's also enough to get the files
-   ``docker-compose.yml`` and ``.env``.
+   If cloning is too much of a hassle, you can also download the files from
+   https://github.com/zammad/zammad-docker-compose/releases. This will make sure
+   file permissions are preserved.
 
 Step 2: Setting vm.max_map_count for Elasticsearch
 --------------------------------------------------


### PR DESCRIPTION
Follow-up for https://github.com/zammad/zammad-docker-compose/issues/382. The manual docker compose download instructions were wrong, as they didn't cover all required files. I now suggest a simpler method that will get all files and also preserve file permissions.