### PR TITLE
Elasticsearch 8 - Add a note for default configuration

### DIFF
--- a/install/elasticsearch.rst
+++ b/install/elasticsearch.rst
@@ -176,7 +176,7 @@ Step 3: Connect Zammad
 
 .. note:: 
 
-   If you use Elasticsearch 8, you need to use an encrypted URL in
+   If you use Elasticsearch 8+, you need to use an HTTPS URL in
    'es_url' as 'https://localhost:9200' and configure an
    Authentication (see HTTP Basic below).
 

--- a/install/elasticsearch.rst
+++ b/install/elasticsearch.rst
@@ -169,14 +169,17 @@ Step 3: Connect Zammad
 .. code-block:: sh
 
    # Set the Elasticsearch server address
-   $ zammad run rails r "Setting.set('es_url', 'https://localhost:9200')"
-
-   # Set the Elasicsearch credentials if needed
-   $ zammad run rails r "Setting.set('es_user', '<username>')"
-   $ zammad run rails r "Setting.set('es_password', '<password>')"
+   $ zammad run rails r "Setting.set('es_url', 'http://localhost:9200')"
 
    # Build the search index
    $ zammad run rake zammad:searchindex:rebuild
+
+.. note:: 
+
+   If you use Elasticsearch 8, you need to use an encrypted URL in
+   'es_url' as 'https://localhost:9200' and configure an
+   Authentication (see HTTP Basic below).
+
 
 Optional settings
 -----------------

--- a/install/elasticsearch.rst
+++ b/install/elasticsearch.rst
@@ -173,7 +173,7 @@ Step 3: Connect Zammad
 
    # Build the search index
    $ zammad run rake zammad:searchindex:rebuild
-   
+
    # Optionally, you can specify a number of CPU cores which are used for
    # rebuilding the searchindex, as in the following example with 8 cores:
    $ zammad run rake zammad:searchindex:rebuild[8]

--- a/install/elasticsearch.rst
+++ b/install/elasticsearch.rst
@@ -169,7 +169,11 @@ Step 3: Connect Zammad
 .. code-block:: sh
 
    # Set the Elasticsearch server address
-   $ zammad run rails r "Setting.set('es_url', 'http://localhost:9200')"
+   $ zammad run rails r "Setting.set('es_url', 'https://localhost:9200')"
+
+   # Set the Elasicsearch credentials if needed
+   $ zammad run rails r "Setting.set('es_user', '<username>')"
+   $ zammad run rails r "Setting.set('es_password', '<password>')"
 
    # Build the search index
    $ zammad run rake zammad:searchindex:rebuild


### PR DESCRIPTION
- By default Elasticsearch 8 will use an http**s** connection
- Add commands to define Elasticsearch user / password