### PR TITLE
Fixes #445 - Add link to translation chapter as an alternative to the Rails command.

### DIFF
--- a/admin/console/other-useful-commands.rst
+++ b/admin/console/other-useful-commands.rst
@@ -38,6 +38,13 @@ has been parsed successfully.
 Add translation
 ---------------
 
+.. warning::
+
+   Although the procedure described below still works, it is not recommended for usage any more.
+
+   Since Zammad version 6.3 it's possible to customize any translation via graphical UI. All coupled with handy
+   suggestions for all translatable custom objects in the local system. For more information, see the documentation for the :admin-docs:`translations screen </system/translations.html>`.
+
 This comes in handy if you e.g. added a new state that you need to translate
 for several languages.
 


### PR DESCRIPTION
Rather than removing the command example completely at this point, a friendly warning is put on top with a link to the relevant section in the admin docs.

This should be communicated to the team, and after collecting their feedback possibly dropped later. Note that there are other similar commands like this which are obsolete with Zammad 6.3.