### PR TITLE
Maintenance: Drop obsolete worldmap-panel plugin requirement

### DIFF
--- a/appendix/reporting-tools-thirdparty/grafana.rst
+++ b/appendix/reporting-tools-thirdparty/grafana.rst
@@ -19,8 +19,7 @@ Overview
    * `The Dashboards`_
 
 You will need
-   * A Grafana 7.5+ instance (hosted or self hosted)
-   * `Worldmap panel plugin <https://grafana.com/grafana/plugins/grafana-worldmap-panel/>`_ 
+   * A Grafana 10.3+ instance (hosted or self hosted)
 
 .. include:: include-requirements.rst
 


### PR DESCRIPTION
The `worldmap-panel` plugin in Grafana has a builtin panel `geomap` which replaces the plugin.
The Dashboards have been updated to reflect the obsolation, thus the documentation should as well. :-)

As this is already live on grafana.com and our Grafana-Repo, this is save to be put into stable as well.