### PR TITLE
email_address_id 3

### DIFF
--- a/api/group.rst
+++ b/api/group.rst
@@ -134,7 +134,7 @@ Required permission: ``admin.group``
    {
      "name": "Amazing Group",
      "signature_id": 1,
-     "email_address_id": 1,
+     "email_address_id": 3,
      "assignment_timeout": 180,
      "follow_up_possible": "new_ticket",
      "follow_up_assignment": false,


### PR DESCRIPTION
The given and requested "email_address_id" should be the same as in the response.
Makes no sense to return another "email_address_id" than requested.