### PR TITLE
Adds required CSRF token fix for using Caddy with HTTPS

### DIFF
--- a/getting-started/include-csrf-hints.rst
+++ b/getting-started/include-csrf-hints.rst
@@ -21,3 +21,10 @@
 
          RequestHeader set X_FORWARDED_PROTO 'https'
          RequestHeader set X-Forwarded-Ssl on
+
+   caddy
+      Add the following line to your Zammad .env file:
+
+      .. code-block::
+
+         NGINX_SERVER_SCHEME=https    


### PR DESCRIPTION
Tested and working on Zammad 6.3.1. Without this the familiar CSRF error appears when using reverse proxy.