### PR TITLE
Update timeaccounting.rst - Endpoint Path Spelling Correction

### DIFF
--- a/api/ticket/timeaccounting.rst
+++ b/api/ticket/timeaccounting.rst
@@ -112,7 +112,7 @@ Update
 
 Required permission: ``admin.time_accounting``
 
-``PUT``-Request sent: ``/api/v1/tickets/{ticket id}/time_accounting/{timeaccounting id}``
+``PUT``-Request sent: ``/api/v1/tickets/{ticket id}/time_accountings/{timeaccounting id}``
 
 
 .. code-block:: json


### PR DESCRIPTION
The time_accountings update URI has a spelling error

Old Spelling
/api/v1/tickets/{ticket id}/time_accounting/{timeaccounting id}

Corrected Spelling
/api/v1/tickets/{ticket id}/time_accountings/{timeaccounting id}