### PR TITLE
Draft: Add Debian 13 as supported distro & install instructions

### DIFF
--- a/install/package.rst
+++ b/install/package.rst
@@ -170,12 +170,12 @@ Add Repository
          .. code-block:: console
 
             $ curl -fsSL https://dl.packager.io/srv/zammad/zammad/key | \
-               gpg --dearmor | sudo tee /etc/apt/keyrings/pkgr-zammad.gpg> /dev/null
+               gpg --dearmor | sudo tee /usr/share/keyrings/pkgr-zammad-keyring.gpg> /dev/null
 
       Debian 11
          .. code-block:: console
 
-            $ echo "deb [signed-by=/etc/apt/keyrings/pkgr-zammad.gpg] https://dl.packager.io/srv/deb/zammad/zammad/stable/debian 11 main"| \
+            $ echo "deb [signed-by=/usr/share/keyrings/pkgr-zammad-keyring.gpg] https://dl.packager.io/srv/deb/zammad/zammad/stable/debian 11 main"| \
                sudo tee /etc/apt/sources.list.d/zammad.list > /dev/null
 
       Debian 12
@@ -189,7 +189,17 @@ Add Repository
             URIs: https://dl.packager.io/srv/deb/zammad/zammad/stable/debian
             Suites: 12
             Components: main
-            Signed-By: /etc/apt/keyrings/pkgr-zammad.gpg" | \
+            Signed-By: /usr/share/keyrings/pkgr-zammad-keyring.gpg" | \
+            sudo tee /etc/apt/sources.list.d/zammad.sources > /dev/null
+
+      Debian 13
+         .. code-block:: console
+
+            $ printf "Types: deb
+            URIs: https://dl.packager.io/srv/deb/zammad/zammad/stable/debian
+            Suites: 13
+            Components: main
+            Signed-By: /usr/share/keyrings/pkgr-zammad-keyring.gpg" | \
             sudo tee /etc/apt/sources.list.d/zammad.sources > /dev/null
 
    .. tab:: OpenSUSE / SLES

--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -67,7 +67,7 @@ Below you can find all distributions Zammad provides packages for.
    :widths: 20, 20
 
    "CentOS / RHEL", "8 & 9"
-   "Debian", "11 & 12"
+   "Debian", "11, 12 & 13"
    "OpenSUSE / SLES", "Leap 15.x / 15"
    "Ubuntu", "22.04 & 24.04"
 


### PR DESCRIPTION
- Added Debian 13 as supported distro
- Added installation instructions for Debian 13
- Changed repo key location to `/usr/share/keyrings/pkgr-zammad-keyring.gpg` for all Debian versions