### PR TITLE
fix(user): typo in data privacy tasks endpoint

### DIFF
--- a/api/user.rst
+++ b/api/user.rst
@@ -1151,7 +1151,7 @@ Via Data Privacy Endpoint
 
 Required permission: ``admin.data_privacy``
 
-``POST``-Request sent: ``/api/v1/data_privacy_task``
+``POST``-Request sent: ``/api/v1/data_privacy_tasks``
 
 .. code-block:: json
 


### PR DESCRIPTION
The documentation for deleting users references the non-existent `/data_privacy_task` endpoint, while the correct one should be `/data_privacy_tasks`.