### PR TITLE
fix(user): update docker compose commands from (deprecated)V1 to V2

### DIFF
--- a/install/update.rst
+++ b/install/update.rst
@@ -206,11 +206,11 @@ using `Zammad hosting`_ for your and your customers' safety.
 
          .. code-block:: console
 
-            $ docker-compose pull
+            $ docker compose pull
 
          .. code-block:: console
 
-            $ docker-compose up -d
+            $ docker compose up -d
 
       Rebuild Elasticsearch index (optional)
          Only needed if the release note tells you to rebuild the Elasticsearch


### PR DESCRIPTION
The update documenations used the docker-compose V1 cli version, which have been deprecated.

But everywhere else in the zammad doc the V2 is used `docker compose <command>`