### PR TITLE
Update software.rst - libimlib2 provider on Debian 13

### DIFF
--- a/prerequisites/software.rst
+++ b/prerequisites/software.rst
@@ -105,19 +105,31 @@ automatically be installed with the Zammad-Package.
 
 .. tabs::
 
-   .. tab:: Debian & Ubuntu
+   .. group-tab:: Ubuntu
 
       .. code-block:: console
 
          $ sudo apt install libimlib2
 
-   .. tab:: openSUSE / SLES
+   .. group-tab:: Debian
+
+      Debian 13
+         .. code-block:: console
+
+            $ sudo apt install libimlib2t64
+
+      Debian 11 & 12
+         .. code-block:: console
+
+            $ sudo apt install libimlib2
+
+   .. group-tab:: openSUSE / SLES
 
       .. code-block:: console
 
          $ sudo zypper install imlib2
 
-   .. tab:: CentOS / RHEL
+   .. group-tab:: CentOS / RHEL
 
       .. code-block:: console
 


### PR DESCRIPTION
Debian : libimlib2 packages have been updated to libimlib2t64 on Trixie (13)

- https://packages.debian.org/search?suite=default&section=all&arch=any&lang=fr&searchon=names&keywords=libimlib2
- https://packages.debian.org/fr/trixie/libimlib2t64