### PR TITLE
Document ZAMMAD_HTTP_TOTAL_TIMEOUT environment variable

### DIFF
--- a/appendix/environment-variables.rst
+++ b/appendix/environment-variables.rst
@@ -433,6 +433,14 @@ ZAMMAD_HTTP_READ_TIMEOUT
    has been established (e.g. if you have a slow connection or slow response
    times on external side).
 
+ZAMMAD_HTTP_TOTAL_TIMEOUT
+   Default: ``60``
+
+   Defines the maximum total time in seconds for the complete HTTP request,
+   wrapping connection establishment and response read. This is an additional
+   hard ceiling on top of ``ZAMMAD_HTTP_OPEN_TIMEOUT`` and
+   ``ZAMMAD_HTTP_READ_TIMEOUT``.
+
 .. |package| image:: /images/package.svg
    :height: 24px
    :width: 24px


### PR DESCRIPTION
Adds documentation for the new `ZAMMAD_HTTP_TOTAL_TIMEOUT` environment variable to the HTTP Client Settings appendix, alongside the existing `ZAMMAD_HTTP_OPEN_TIMEOUT` and `ZAMMAD_HTTP_READ_TIMEOUT` entries.

This documents the ENV-var escape hatch introduced for `UserAgent.make_connection`'s outer `Timeout.timeout` wrapper (default 60s, backward compatible; per-request `options[:total_timeout]` still overrides).

The corresponding code change is on its way to develop in zammad/zammad.