### PR TITLE
Document X-Zammad-Suppress-Notifications header for ticket update API

### DIFF
--- a/api/ticket/index.rst
+++ b/api/ticket/index.rst
@@ -257,20 +257,19 @@ Required permission: ``ticket.agent`` **or** ``ticket.customer``
 
 .. tip::
 
-   **🔕 Suppress notifications**
+   **Suppress notifications**
 
    To update a ticket without triggering agent notifications (email and
-   in-app), add the following HTTP header to your request::
+   in-app), add the following HTTP header to your request:
+
+   .. code-block:: text
 
       X-Zammad-Suppress-Notifications: true
 
    This is useful for automated integrations that update tickets via
-   webhooks or triggers to avoid notification loops. The header is
-   available to **agents and admins only** — it is silently ignored
-   for customers.
-
-   The header also works on the ``POST /api/v1/ticket_articles``
-   endpoint and the GraphQL ``ticketUpdate`` mutation.
+   webhooks or triggers to avoid notification loops. The header only affects
+   admin and agent accounts and is ignored for customers. It also works for the
+   ``POST /api/v1/ticket_articles`` endpoint.
 
 ``PUT``-Request sent: ``/api/v1/tickets/{ticket id}``
 

--- a/api/ticket/index.rst
+++ b/api/ticket/index.rst
@@ -255,6 +255,23 @@ Update
 
 Required permission: ``ticket.agent`` **or** ``ticket.customer``
 
+.. tip::
+
+   **🔕 Suppress notifications**
+
+   To update a ticket without triggering agent notifications (email and
+   in-app), add the following HTTP header to your request::
+
+      X-Zammad-Suppress-Notifications: true
+
+   This is useful for automated integrations that update tickets via
+   webhooks or triggers to avoid notification loops. The header is
+   available to **agents and admins only** — it is silently ignored
+   for customers.
+
+   The header also works on the ``POST /api/v1/ticket_articles``
+   endpoint and the GraphQL ``ticketUpdate`` mutation.
+
 ``PUT``-Request sent: ``/api/v1/tickets/{ticket id}``
 
 .. code-block:: json


### PR DESCRIPTION
## Summary

Documents the new `X-Zammad-Suppress-Notifications: true` HTTP header introduced in zammad/zammad#6042.

Adds a tip block to the **Update** section of the Tickets API page explaining:
- How to use the header to suppress agent notifications (email + in-app)
- That it targets automated integrations to avoid notification loops
- Permission scope: agents and admins only, ignored for customers
- That the same header works on `POST /api/v1/ticket_articles` and the GraphQL `ticketUpdate` mutation

## Related

- Implementation MR: https://git.zammad.com/zammad/zammad/-/merge_requests/13394
- GitHub issue: https://github.com/zammad/zammad/issues/6042