### PR TITLE
Maintenance: Move suppress-notifications tip to top of ticket API page

### DIFF
--- a/api/ticket/index.rst
+++ b/api/ticket/index.rst
@@ -6,6 +6,21 @@ Tickets
    Ticket endpoints depend on group permissions and if the user you're
    using is an **agent**. Because of this tickets may or may not be available.
 
+.. tip::
+
+   **Suppress notifications**
+
+   To create or update a ticket without triggering agent notifications (email and
+   in-app), add the following HTTP header to your request:
+
+   .. code-block:: text
+
+      X-Zammad-Suppress-Notifications: true
+
+   This is useful for automated integrations that manage tickets via
+   webhooks or triggers to avoid notification loops. The header only affects
+   admin and agent accounts and is ignored for customers.
+
 List
 ----
 
@@ -275,22 +290,6 @@ Update
 ------
 
 Required permission: ``ticket.agent`` **or** ``ticket.customer``
-
-.. tip::
-
-   **Suppress notifications**
-
-   To update a ticket without triggering agent notifications (email and
-   in-app), add the following HTTP header to your request:
-
-   .. code-block:: text
-
-      X-Zammad-Suppress-Notifications: true
-
-   This is useful for automated integrations that update tickets via
-   webhooks or triggers to avoid notification loops. The header only affects
-   admin and agent accounts and is ignored for customers. It also works for the
-   ``POST /api/v1/ticket_articles`` endpoint.
 
 ``PUT``-Request sent: ``/api/v1/tickets/{ticket id}``
 


### PR DESCRIPTION
The X-Zammad-Suppress-Notifications header works for both ticket create and update. Moving the tip from the Update section to the top of the page ensures readers discover it regardless of which endpoint they start with.