### PR TITLE
Document the non-superuser PostgreSQL role of the Docker Compose stack

### DIFF
--- a/appendix/environment-variables.rst
+++ b/appendix/environment-variables.rst
@@ -305,9 +305,9 @@ POSTGRES_SUPERUSER |docker|
    such as creating extensions or dumping globals. It is applied when the
    database volume is initialized, changing it later has no effect.
 
-   This must differ from ``POSTGRES_USER``, otherwise Zammad would connect as
-   the superuser. The database service then stays unhealthy and the rest of the
-   stack does not start.
+   When a database volume is initialized, this must differ from
+   ``POSTGRES_USER``, otherwise Zammad would connect as the superuser. The
+   database is then not created and the service stays unhealthy.
 
 POSTGRES_SUPERUSER_PASS |docker|
    Default: the value of ``POSTGRES_PASS``, which itself defaults to ``zammad``

--- a/appendix/environment-variables.rst
+++ b/appendix/environment-variables.rst
@@ -305,11 +305,17 @@ POSTGRES_SUPERUSER |docker|
    such as creating extensions or dumping globals. It is applied when the
    database volume is initialized, changing it later has no effect.
 
-POSTGRES_SUPERUSER_PASS |docker|
-   Default: ``zammad``
+   This must differ from ``POSTGRES_USER``, otherwise Zammad would connect as
+   the superuser. The database service then stays unhealthy and the rest of the
+   stack does not start.
 
-   The password of the administrative superuser. It is applied when the database
-   volume is initialized, changing it later has no effect.
+POSTGRES_SUPERUSER_PASS |docker|
+   Default: the value of ``POSTGRES_PASS``, which itself defaults to ``zammad``
+
+   The password of the administrative superuser. Set this only if the superuser
+   should use a different password than Zammad's own database role. It is
+   applied when the database volume is initialized, changing it later has no
+   effect.
 
 POSTGRESQL_OPTIONS
    Default: ``?pool=50``

--- a/appendix/environment-variables.rst
+++ b/appendix/environment-variables.rst
@@ -283,7 +283,9 @@ POSTGRES_PORT |docker|
 POSTGRES_USER |docker|
    Default: ``zammad``
 
-   The database user for Zammad.
+   The database user for Zammad. In the Docker Compose stack this is an
+   unprivileged login role that owns Zammad's database, but holds no superuser
+   privileges. It is created when the database volume is initialized.
 
 POSTGRES_PASS |docker|
    Default: ``zammad``
@@ -295,16 +297,36 @@ POSTGRES_DB |docker|
 
    Zammad's database to use.
 
+POSTGRES_SUPERUSER |docker|
+   Default: ``postgres``
+
+   The administrative superuser of the PostgreSQL service in the Docker Compose
+   stack. Zammad never connects with it, it only exists for maintenance tasks
+   such as creating extensions or dumping globals. It is applied when the
+   database volume is initialized, changing it later has no effect.
+
+POSTGRES_SUPERUSER_PASS |docker|
+   Default: ``zammad``
+
+   The password of the administrative superuser. It is applied when the database
+   volume is initialized, changing it later has no effect.
+
 POSTGRESQL_OPTIONS
    Default: ``?pool=50``
 
    Additional PostgreSQL params to be appended to the database URI.
 
 POSTGRESQL_DB_CREATE
-   Default: ``true``
+   Default: ``true``, but ``false`` in the Docker Compose stack
 
-   By default, Zammad creates the required database. On already existing
-   database servers, the default might be troublesome.
+   By default, Zammad creates the required database on startup. On already
+   existing database servers, the default might be troublesome.
+
+   The Docker Compose stack sets this to ``false``, because its PostgreSQL
+   service creates the database up front and the role Zammad connects with is
+   deliberately not allowed to create databases. Set it to ``true`` if you use
+   an external database server and want Zammad to create the database itself.
+   The configured database user then needs the ``CREATEDB`` attribute.
 
 Nginx
 -----


### PR DESCRIPTION
Documentation follow-up for zammad/zammad-docker-compose#611, which makes the Docker Compose stack run Zammad against an unprivileged PostgreSQL role instead of the `postgres` image's bootstrap superuser. Refs zammad/coordination-technical-debt#854.

Changes to `appendix/environment-variables.rst`:

* `POSTGRES_USER` — clarifies that in the Docker Compose stack this is an unprivileged login role owning Zammad's database, created when the database volume is initialized.
* `POSTGRES_SUPERUSER` and `POSTGRES_SUPERUSER_PASS` — new variables for the administrative superuser of the stack's PostgreSQL service, which Zammad itself never uses.
* `POSTGRESQL_DB_CREATE` — the image default stays `true`, but the Docker Compose stack now sets `false`, because it creates the database up front and the Zammad role has no `CREATEDB` attribute. Documents that an external database server needs `true` plus a role holding `CREATEDB`.

The migration steps for existing installations are intentionally not repeated here — they are a one-off upgrade concern and live in the stack's [README](https://github.com/zammad/zammad-docker-compose#postgresql-privileges) and the release notes. Happy to add them to the install docs instead if you prefer them here.

Verified with `rstcheck[sphinx]<=6.1.0`, the same version the `Check RST Syntax` CI step uses: no issues in the changed file.

Please merge only together with (or after) zammad/zammad-docker-compose#611.