### PR TITLE
Fixes #901 - Explain NGINX_SERVER_SCHEME in the HTTPS scenarios

### DIFF
--- a/install/docker-compose/docker-compose-scenarios.rst
+++ b/install/docker-compose/docker-compose-scenarios.rst
@@ -82,7 +82,17 @@ Making the Stack Available via HTTPS
 ------------------------------------
 
 If you set up Zammad for production use, it needs to be secured by using an
-HTTPS connection. There are different scenarios for achieving this:
+HTTPS connection. There are different scenarios for achieving this, which have
+one thing in common:
+
+The scenarios below publish Zammad through a reverse proxy that terminates TLS
+and forwards plain HTTP to Zammad. Zammad's own Nginx overwrites the
+``X-Forwarded-Proto`` header with the scheme of the connection it receives, so
+the scenarios set the environment variable ``NGINX_SERVER_SCHEME`` to
+``https``. Without it, Zammad does not write its session cookie and login
+fails with a CSRF token verification error. The default from the scenario
+files is usually correct, see :doc:`environment variables
+</appendix/environment-variables>` if you need to change it.
 
 Add Cloudflare Tunnel
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The scenarios that terminate TLS at a reverse proxy set NGINX_SERVER_SCHEME=https themselves since zammad-docker-compose#614. Document why on the scenarios page: Zammad's bundled Nginx overwrites X-Forwarded-Proto, so the scheme must be configured in Zammad's own Nginx or the 'Secure' session cookie is never written and login fails with a CSRF token verification error.

Related issue: https://github.com/zammad/zammad-documentation/issues/901