### PR TITLE
docs(api): "Removing organizations" → "groups" in group delete note

### DIFF
--- a/api/group.rst
+++ b/api/group.rst
@@ -221,7 +221,7 @@ Required permission: ``admin.group``
 
    Please note that removing groups cannot be undone.
 
-   Removing organizations with references in e.g. activity streams or tickets
+   Removing groups with references in e.g. activity streams or tickets
    is not possible via API - this will be indicated by
    ``"error": "Can't delete, object has references."``. This is *not* a bug.
 


### PR DESCRIPTION
The delete note in the Groups API doc said "Removing organizations
with references…", though this endpoint is about groups — a copy from
organization.rst where it is correct. Fixed to "groups".

Scope: 1 line in api/group.rst (organization.rst:249 left as-is).